### PR TITLE
Build OCI images with common pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,7 @@ cloud.gov maintains a variety of software written in a handful of programming la
 * Developers should be able to adopt common pipelines into their pipeline with a minimum of effort. Zero or one lines of code would be ideal.
 * The configuration options for each pipeline should be minimal. They're the API of the pipelines; keep it simple.
 * Favor convention over configuration. Repositories using common pipelines should "just work" if their folders and files are in the right place.
+
+## Development
+
+If you want to iterate on a pipeline in this repository, consider pushing your changes to a topic branch. Topic branches do not have merge protection, so you will be able to iterate more quickly without getting pull requests approved. Change your `pipeline.yml` in your downstream repository to reference your topic branch instead of `main` in the `common-pipelines` resource to continuously pull in your changes. (You can consider working on a topic branch in your downstream repo as well.)

--- a/container/README.md
+++ b/container/README.md
@@ -1,0 +1,48 @@
+# OCI Pipeline
+
+Build, audit, and scan Open Container Initiative (OCI) images on PR, and push them to a registry on merge if they pass all audits and scans.
+
+## Usage
+
+In addition to setting `src-repo` in CredHub (see [the repository README](../README.md#Usage)), you must copy `vars.yml` to `ci/vars.yml` in your repository. The vars in the file may be assigned empty maps:
+
+```yaml
+# vars.yml
+oci-build-params: {}
+```
+
+Or you can populate the maps with params to pass to individual steps:
+
+```yaml
+# example: the oci-build step accepts a map named `oci-build-params`
+# vars.yml
+oci-build-params:
+  CONTEXT: src # set OCI build context to a folder in the repository instead of the root
+  DOCKERFILE: build/docker/Dockerfile # specify Dockerfile location when it is not in the repository root
+```
+
+Most params have reasonable defaults and don't need to be explicitly set. Test with your repository to find out.
+
+Note that `vars.yml` cannot be empty; it must include maps, even empty ones, for every parameter specified in the pipeline, or the `set-self` job will fail because it cannot find the vars.
+
+Since the vars file is in a GitHub repository, it cannot contain sensitive params. Storing the vars in CredHub would be better but is not currently possible; see "Design choices" below.
+
+## Design choices
+
+### Why load step params from a map instead of individually?
+
+The current approach groups task parameters into a map (see [Usage](#Usage)) and sets the entire map "structurally" on the task at once. An alternative approach would be eliding the map and specifying each parameter in the vars file or CredHub separately, like:
+
+```yaml
+# vars.yml
+CONTEXT: src
+DOCKERFILE: Dockerfile
+```
+
+However, using that approach, every single parameter that might be used by _any_ consumer of the pipeline must be surfaced up-front and be specified in `vars.yml` by _every_ consumer of the pipeline, even if you want to omit a parameter so you take the task default. This requires more up-front work for users of the pipeline and makes it impossible to simplify configuration by accepting the task's default param value.
+
+In other words, this approach results in the smallest API surface and least implementation burden for consumers of the pipeline.
+
+### Why load step params from a vars file in your repository instead of CredHub?
+
+Vars in CredHub of type `json` are not [structurally substituted](https://concourse-ci.org/vars.html#var-interpolation) like vars in a local yaml (or JSON!) file. Without structural substitution, you'd need to set each value individually; see the previous section for why this would create more work. (Issue or discussion on Concourse repo forthcoming.)

--- a/container/oci-build.yml
+++ b/container/oci-build.yml
@@ -1,0 +1,20 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    repository: concourse/oci-build-task
+
+inputs:
+- name: src
+
+outputs:
+- name: image
+
+run:
+  dir: src
+  path: build
+
+params:
+  BUILD_ARG_TOKEN: ((ubuntu-advantage-token))

--- a/container/pipeline.yml
+++ b/container/pipeline.yml
@@ -1,0 +1,74 @@
+jobs:
+- name: set-self
+  plan:
+    - get: common-pipelines
+      trigger: true
+    - get: src
+      trigger: false
+    - set_pipeline: self
+      file: common-pipelines/container/pipeline.yml
+      var_files:
+        - src/container/ci/vars.yml
+
+- name: pull-request
+  plan:
+    - get: pull-request
+      version: every
+      trigger: true
+
+    - get: common-pipelines
+      passed: [set-self]
+
+    - put: pull-request
+      params:
+        path: pull-request
+        status: pending
+
+    - task: oci-build
+      privileged: true
+      file: common-pipelines/container/oci-build.yml
+      input_mapping:
+        src: pull-request
+      params: ((oci-build-params)) # for available params, see https://github.com/concourse/oci-build-task#params
+
+  on_failure:
+    put: pull-request
+    params:
+      path: pull-request
+      status: failure
+
+resources:
+
+- name: common-pipelines
+  type: git
+  source:
+    uri: https://github.com/cloud-gov/common-pipelines
+    branch: main
+    commit_verification_keys: ((cloud-gov-pgp-keys))
+
+- name: src
+  type: git
+  source:
+    uri: https://github.com/((src-repo))
+    branch: main
+    commit_verification_keys: ((cloud-gov-pgp-keys))
+
+- name: pull-request
+  type: pull-request
+  check_every: 1m
+  source:
+    repository: ((src-repo))
+    access_token: ((cg-ci-bot-ghtoken))
+    disable_forks: true
+    base_branch: main
+
+resource_types:
+- name: slack-notification
+  type: registry-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+
+- name: pull-request
+  type: registry-image
+  source:
+    repository: teliaoss/github-pr-resource

--- a/container/vars.yml
+++ b/container/vars.yml
@@ -1,0 +1,2 @@
+# All empty by default. See README.md#Usage for details.
+oci-build-params: {}


### PR DESCRIPTION
## Changes proposed in this pull request:

Retrying this PR since I messed up the last one with a bad force push. (Thank goodness for the reflog.)

- Support building images using a new `container` common pipeline.
- Related to https://github.com/cloud-gov/product/issues/2567. 

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Uses same 3rd party containers as other steps. To be addressed later in the epic.
