### PR TITLE
Port container auditing script from container-scanning

### DIFF
--- a/container/oci-build.yml
+++ b/container/oci-build.yml
@@ -13,8 +13,11 @@ outputs:
 - name: image
 
 run:
-  dir: src
   path: build
 
 params:
+  # Required for running 'usg' hardening tool.
   BUILD_ARG_TOKEN: ((ubuntu-advantage-token))
+  # Required to use the image in later steps.
+  UNPACK_ROOTFS: true
+  CONTEXT: src

--- a/container/parse_cis_audit_html.py
+++ b/container/parse_cis_audit_html.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+import argparse
+from bs4 import BeautifulSoup
+
+__DESCRIPTION__ = """
+Search for failed scan results to determine if an image can
+be promoted from staging to production
+"""
+# This is a script to parse the output of
+# the usg audit in html from cis-audit.html
+
+
+def main():
+    """This is the logic for finding out if there are any failed cves"""
+    status = "passed"
+    args = get_args()
+    with open(args.inputfile, encoding="utf-8") as file_pointer:
+        soup = BeautifulSoup(file_pointer, 'html.parser')
+    divs = soup.findAll('div', {"class": "progress-bar"})
+    for div in divs:
+        progress_line = div.getText()
+        if progress_line.find("failed") > 0:
+            lines = progress_line.split()
+            if len(lines) > 1 and int(lines[0]) > 0:
+                status = "failed"
+    print(status)
+
+
+def get_args():
+    """Parse the arguments looking for just one, inputfile"""
+    parser = argparse.ArgumentParser(description=__DESCRIPTION__)
+    parser.add_argument('--inputfile', help="the cis-audit html file>")
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    main()

--- a/container/pipeline.yml
+++ b/container/pipeline.yml
@@ -31,11 +31,16 @@ jobs:
         src: pull-request
       params: ((oci-build-params)) # for available params, see https://github.com/concourse/oci-build-task#params
 
+    - task: usg-audit
+      file: common-pipelines/container/usg-audit.yml
+      image: image
+
   on_failure:
     put: pull-request
     params:
       path: pull-request
       status: failure
+
 
 resources:
 

--- a/container/usg-audit.sh
+++ b/container/usg-audit.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -eo pipefail
+
+# set up dir and file
+touch audit/cis-audit.html
+touch audit/cis-audit.xml
+
+echo "Configuring ua attach config"
+cat <<EOF >> ua-attach-config.yaml
+token: $UBUNTU_ADVANTAGE_TOKEN
+enable_services:
+- usg
+- esm-infra
+EOF
+
+apt-get update
+apt-get -y upgrade
+apt-get -y -q install \
+  ubuntu-advantage-tools \
+  ca-certificates \
+  python3-pip
+
+echo "UA attaching"
+ua attach --attach-config ua-attach-config.yaml
+
+apt-get -y -q install usg
+
+echo "installing bs4"
+# Install the python library BeautifulSoup to parse html
+pip3 install beautifulsoup4
+
+# Run cis audit and put html results into cis-audit.html file
+echo "running audit"
+usg audit cis_level1_server --html-file $PWD/audit/cis-audit.html --results-file $PWD/audit/cis-audit.xml
+
+# Parse the resulting cis-audit.html file looking for pass/fail via a python script
+if [ "$(./common-pipelines/container/parse_cis_audit_html.py --inputfile audit/cis-audit.html)" == "failed" ]
+then
+  echo "Container hardening audit FAILED"
+  exit 1
+fi
+
+echo "Container hardening audit PASSED"

--- a/container/usg-audit.yml
+++ b/container/usg-audit.yml
@@ -1,0 +1,15 @@
+---
+platform: linux
+
+inputs:
+- name: common-pipelines
+
+outputs:
+- name: audit
+
+run:
+  path: common-pipelines/container/usg-audit.sh
+
+params:
+  # Required for running 'usg' audit tool.
+  UBUNTU_ADVANTAGE_TOKEN: ((ubuntu-advantage-token))


### PR DESCRIPTION
## Changes proposed in this pull request:

- Run `usg audit` on the image output from the `oci-build` step.
- Largely ported from https://github.com/cloud-gov/container-scanning/blob/main/ci/audit-ecr-container.yml and related files

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.
