### PR TITLE
Scan image for CVEs with Grype

### DIFF
--- a/container/grype.yaml
+++ b/container/grype.yaml
@@ -1,0 +1,6 @@
+#Grype ignore configurations.
+
+ignore:
+  - vulnerability: CVE-2007-4642  #false positive, alerting on package of same name
+  - vulnerability: CVE-2007-4644  #false positive, alerting on package of same name
+  - vulnerability: CVE-2018-20225 #disputed as intended functionality

--- a/container/oci-build.yml
+++ b/container/oci-build.yml
@@ -6,6 +6,9 @@ image_resource:
   source:
     repository: concourse/oci-build-task
 
+caches:
+- path: cache
+
 inputs:
 - name: src
 

--- a/container/pipeline.yml
+++ b/container/pipeline.yml
@@ -4,7 +4,7 @@ jobs:
     - get: common-pipelines
       trigger: true
     - get: src
-      trigger: false
+      trigger: true
     - set_pipeline: self
       file: common-pipelines/container/pipeline.yml
       var_files:

--- a/container/pipeline.yml
+++ b/container/pipeline.yml
@@ -18,6 +18,7 @@ jobs:
 
     - get: common-pipelines
       passed: [set-self]
+      trigger: true
 
     - put: pull-request
       params:
@@ -31,9 +32,13 @@ jobs:
         src: pull-request
       params: ((oci-build-params)) # for available params, see https://github.com/concourse/oci-build-task#params
 
-    - task: usg-audit
-      file: common-pipelines/container/usg-audit.yml
-      image: image
+    - in_parallel:
+      - task: usg-audit
+        file: common-pipelines/container/usg-audit.yml
+        image: image
+
+      - task: scan-image
+        file: common-pipelines/container/scan-image.yml
 
   on_failure:
     put: pull-request

--- a/container/scan-image.sh
+++ b/container/scan-image.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+grype image/image.tar -c common-pipelines/container/grype.yaml -q -o json --file cves/output.json
+grype image/image.tar -c common-pipelines/container/grype.yaml -q -o table --file table.txt
+
+cat cves/output.json | jq '.matches | .[]? |  .vulnerability.severity' >> severity.txt
+
+critical=$(grep -o -i critical severity.txt | wc -l)
+high=$(grep -o -i high severity.txt | wc -l)
+medium=$(grep -o -i medium severity.txt | wc -l)
+low=$(grep -o -i low severity.txt | wc -l)
+negligible=$(grep -o -i negligible severity.txt | wc -l)
+
+echo "Critical: $critical"
+echo "High: $high"
+echo "Medium: $medium"
+echo "Low: $low"
+echo "Negligible: $negligible"
+
+cat table.txt

--- a/container/scan-image.yml
+++ b/container/scan-image.yml
@@ -1,0 +1,21 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: harden-concourse-task
+    aws_region: us-gov-west-1
+    semver_constraint: ">= 1.0.0"
+
+inputs:
+- name: common-pipelines
+- name: image
+
+outputs:
+- name: cves
+
+run:
+  path: common-pipelines/container/scan-image.sh


### PR DESCRIPTION
## Changes proposed in this pull request:

- Ports image scanning work from container-scanning repository largely as-is with minimal changes to work in common-pipelines model
- Enable OCI build cache to speed image builds
- Make source repository updates a trigger so pipelines are updated with new vars

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

CVE output is sensitive but is only output to Concourse build logs at the moment. 

Related to https://github.com/cloud-gov/product/issues/2567