### PR TITLE
Filter CVE scan results on PR and merge to main

### DIFF
--- a/container/cve-check.sh
+++ b/container/cve-check.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+#Check dates of Critical and High CVEs
+cat cves/output.json | jq -r '.matches | .[] | select(.vulnerability.severity == "Critical") | if .vulnerability.id | test("CVE") then .vulnerability.id else .relatedVulnerabilities[].id end' > critical_cves.txt
+cat cves/output.json | jq -r '.matches | .[] | select(.vulnerability.severity == "High") | if .vulnerability.id | test("CVE") then .vulnerability.id else .relatedVulnerabilities[].id end' > high_cves.txt
+
+past_due_critical_cves=()
+past_due_high_cves=()
+current_critical_cves=()
+current_high_cves=()
+failed_cves=()
+
+#check list of Critical CVEs
+while read cve; do
+    if ! echo ${past_due_critical_cves[@]} | grep -q -w "$cve" && ! echo ${current_critical_cves[@]} | grep -q -w "$cve"
+    then
+      response=$(curl -fs --retry 3 https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=$cve)
+      if [ $? -eq 0 ] #if curl is successful
+      then
+          modified_date=$(echo $response | jq -r '.vulnerabilities[].cve.lastModified')
+          cve_date=$(date -d $modified_date  +"%Y%m%d")
+          cutoff_date=$(date +"%Y%m%d" -d "-15 days")
+          if [ $cve_date -lt $cutoff_date ]
+          then
+              past_due_critical_cves+=("$cve")
+          else
+              current_critical_cves+=("$cve")
+          fi
+      else
+          failed_cves+=("$cve")
+      fi
+    fi
+    sleep 10
+done < critical_cves.txt
+
+#check list of High CVEs
+while read cve; do
+    if ! echo ${past_due_high_cves[@]} | grep -q -w "$cve" && ! echo ${current_high_cves[@]} | grep -q -w "$cve"
+    then
+      response=$(curl -fs --retry 3 https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=$cve)
+      if [ $? -eq 0 ] #if curl is successful
+      then
+          modified_date=$(echo $response | jq -r '.vulnerabilities[].cve.lastModified')
+          cve_date=$(date -d $modified_date  +"%Y%m%d")
+          cutoff_date=$(date +"%Y%m%d" -d "-30 days")
+          if [ $cve_date -lt $cutoff_date ]
+          then
+              past_due_high_cves+=("$cve")
+          else
+              current_high_cves+=("$cve")
+          fi
+      else
+          failed_cves+=("$cve")
+      fi
+    fi
+    sleep 10
+done < high_cves.txt
+
+echo "Past Due CVEs"
+echo "  Critical:"
+for past_due_crit_issue in ${past_due_critical_cves[@]}; do
+    echo "      $past_due_crit_issue"
+done
+
+echo "  High:"
+for past_due_high_issue in ${past_due_high_cves[@]}; do
+    echo "      $past_due_high_issue"
+done
+
+echo "Latest CVEs"
+echo "  Critical:"
+for crit_issue in ${current_critical_cves[@]}; do
+    echo "      $crit_issue"
+done
+
+echo "  High:"
+for high_issue in ${current_high_cves[@]}; do
+    echo "      $high_issue"
+done
+
+echo "Unknown Issues: (No date found)"
+for failed_issue in ${failed_cves[@]}; do
+    echo "      $failed_issue"
+done
+
+if [ ${#past_due_critical_cves[@]} -ge 1 ] || [ ${#past_due_high_cves[@]} -ge 1 ]
+then exit 1
+fi
+
+if [ ${#current_critical_cves[@]} -ge 1 ] || [ ${#current_high_cves[@]} -ge 1 ]
+then echo ":warning: CVEs need to be reviewed for image ${IMAGENAME}." > message/alert.txt
+else echo ":white_check_mark: ${IMAGENAME} passed CVE check" > message/alert.txt
+fi

--- a/container/cve-check.yml
+++ b/container/cve-check.yml
@@ -4,8 +4,8 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    aws_access_key_id: ((aws-key))
-    aws_secret_access_key: ((aws-secret))
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
     repository: harden-concourse-task
     aws_region: us-gov-west-1
     semver_constraint: ">= 1.0.0"

--- a/container/cve-check.yml
+++ b/container/cve-check.yml
@@ -1,0 +1,21 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    aws_access_key_id: ((aws-key))
+    aws_secret_access_key: ((aws-secret))
+    repository: harden-concourse-task
+    aws_region: us-gov-west-1
+    semver_constraint: ">= 1.0.0"
+
+inputs:
+- name: common-pipelines
+- name: cves
+
+outputs:
+- name: message
+
+run:
+  path: common-pipelines/container/cve-check.sh

--- a/container/grype.yaml
+++ b/container/grype.yaml
@@ -1,6 +1,7 @@
 #Grype ignore configurations.
 
 ignore:
-  - vulnerability: CVE-2007-4642  #false positive, alerting on package of same name
-  - vulnerability: CVE-2007-4644  #false positive, alerting on package of same name
-  - vulnerability: CVE-2018-20225 #disputed as intended functionality
+  - vulnerability: CVE-2007-4642   #false positive, alerting on package of same name
+  - vulnerability: CVE-2007-4644   #false positive, alerting on package of same name
+  - vulnerability: CVE-2018-20225  #disputed as intended functionality
+  - vulnerability: CVE-2018-9057   #false positive as outlined here: https://github.com/anchore/grype/issues/1377

--- a/container/pipeline.yml
+++ b/container/pipeline.yml
@@ -93,7 +93,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/common-pipelines
-    branch: cve-check
+    branch: main
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
 - name: pull-request
@@ -114,7 +114,7 @@ resources:
   type: git
   source:
     uri: https://github.com/((src-repo))
-    branch: test-pr
+    branch: main
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
 resource_types:

--- a/container/pipeline.yml
+++ b/container/pipeline.yml
@@ -37,8 +37,12 @@ jobs:
         file: common-pipelines/container/usg-audit.yml
         image: image
 
-      - task: scan-image
-        file: common-pipelines/container/scan-image.yml
+      - do:
+        - task: scan-image
+          file: common-pipelines/container/scan-image.yml
+
+        - task: cve-check
+          file: common-pipelines/container/cve-check.yml
 
   on_failure:
     put: pull-request
@@ -85,7 +89,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/common-pipelines
-    branch: main
+    branch: cve-check
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
 - name: pull-request
@@ -106,7 +110,7 @@ resources:
   type: git
   source:
     uri: https://github.com/((src-repo))
-    branch: main
+    branch: test-pr
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
 resource_types:

--- a/container/pipeline.yml
+++ b/container/pipeline.yml
@@ -69,8 +69,12 @@ jobs:
         file: common-pipelines/container/usg-audit.yml
         image: image
 
-      - task: scan-image
-        file: common-pipelines/container/scan-image.yml
+      - do:
+        - task: scan-image
+          file: common-pipelines/container/scan-image.yml
+
+        - task: cve-check
+          file: common-pipelines/container/cve-check.yml
 
   on_failure:
     put: slack


### PR DESCRIPTION
## Changes proposed in this pull request:

- See title.
- Ported from container-scanning.
- Related to https://github.com/cloud-gov/product/issues/2567.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None. CVE information is printed to logs in Concourse online, which is only accessible to platform operators.
