### PR TITLE
Change example path to one that is most commonly used

### DIFF
--- a/container/example/pipeline.yml
+++ b/container/example/pipeline.yml
@@ -14,7 +14,7 @@ jobs:
     - set_pipeline: self
       file: common-pipelines/container/pipeline.yml
       var_files:
-        - src/container/ci/vars.yml
+        - src/ci/vars.yml
 
 resources:
 # The repository containing the pipeline you want to use.

--- a/container/pipeline.yml
+++ b/container/pipeline.yml
@@ -8,7 +8,7 @@ jobs:
     - set_pipeline: self
       file: common-pipelines/container/pipeline.yml
       var_files:
-        - src/container/ci/vars.yml
+        - src/ci/vars.yml
 
 - name: pull-request
   plan:


### PR DESCRIPTION
## Changes proposed in this pull request:

- Changes the example path for the vars file to match up with what is commonly used in our pipelines

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just updating an example file
