### PR TITLE
Push on merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Reusable Concourse pipelines. Reference the pipeline for your app's language, `f
 
 ## Usage
 
+See each pipeline folder for pipeline-specific details. The general instructions follow.
+
 Set the `src-repo` value in your repository's Credhub path:
 
 ```sh
@@ -55,3 +57,7 @@ cloud.gov maintains a variety of software written in a handful of programming la
 ## Development
 
 If you want to iterate on a pipeline in this repository, consider pushing your changes to a topic branch. Topic branches do not have merge protection, so you will be able to iterate more quickly without getting pull requests approved. Change your `pipeline.yml` in your downstream repository to reference your topic branch instead of `main` in the `common-pipelines` resource to continuously pull in your changes. (You can consider working on a topic branch in your downstream repo as well.)
+
+## Troubleshooting
+
+If your pipeline shows up as "Archived" in Concourse after running the steps in [Usage](#Usage), the most likely reason is that a branch is wrong, either in `common-pipelines` (if you are using a topic branch to work on a pipeline; see [Development](#Development)) or in your own repository's `ci/pipeline.yml`. Double-check that they all match and set the pipeline again. (You may need to run `fly destroy-pipeline` to remove the archived pipeline.)

--- a/container/README.md
+++ b/container/README.md
@@ -4,7 +4,9 @@ Build, audit, and scan Open Container Initiative (OCI) images on PR, and push th
 
 ## Usage
 
-Copy the contents of [example](example) into folder `ci/` in your repository, set `src-repo` on the appropriate path in CredHub, and run:
+Copy the contents of [example](example) into folder `ci/` in your repository. In the appropriate folder in CredHub, set `src-repo` to the fully qualified name of the repository in GitHub, like `organization/repository`, and set `image-repository` to the ECR repository name, which should be the name of the GitHub repository without the organization.
+
+Once set, run:
 
 ```sh
 fly -t ci set-pipeline --pipeline YOUR-PIPELINE-NAME --config ci/pipeline.yml --load-vars-from ci/vars.yml
@@ -12,7 +14,11 @@ fly -t ci set-pipeline --pipeline YOUR-PIPELINE-NAME --config ci/pipeline.yml --
 
 It is recommended that `YOUR-PIPELINE-NAME` be your repository name so you can find the pipeline easily in Concourse.
 
-The vars in `vars.yml` may be assigned empty maps:
+If problems occur, see [Troubleshooting](#Troubleshooting).
+
+### Vars file
+
+The vars in `your-repo/ci/vars.yml` may be assigned empty maps:
 
 ```yaml
 # vars.yml
@@ -34,6 +40,20 @@ Most params have reasonable defaults and don't need to be explicitly set. Test w
 Note that `vars.yml` cannot be empty; it must include maps, even empty ones, for every parameter specified in the pipeline, or the `set-self` job will fail because it cannot find the vars.
 
 Since the vars file is in a GitHub repository, it cannot contain sensitive params. Storing the vars in CredHub would be better but is not currently possible; see "Design choices" below.
+
+## Troubleshooting
+
+See also [..README.md - Troubleshooting](../README.md#Troubleshooting).
+
+### Failing to push
+
+If the `put: image` step fails and the log shows the following:
+
+```
+retrying Post "https://aws-account-number.dkr.ecr.us-gov-west-1.amazonaws.com/v2/cloud-gov/example-pipeline/blobs/uploads/": EOF
+```
+
+Did you create the repository in ECR first? Did you set `image-repository` in CredHub to the name of the GitHub repository, excluding the GitHub organization?
 
 ## Design choices
 

--- a/container/README.md
+++ b/container/README.md
@@ -57,6 +57,10 @@ Did you create the repository in ECR first? Did you set `image-repository` in Cr
 
 ## Design choices
 
+### Why tag with the git short hash / short_ref?
+
+We build a variety of docker images with a variety of versioning schemes, ranging from "none" to semantic versioning. We may expand our tagging scheme in the future, but for now, the short hash — the first seven characters of the commit SHA — is a tag that works universally and functions as a reference back to the commit the image was built from, which is useful in troubleshooting.
+
 ### Why load step params from a map instead of individually?
 
 The current approach groups task parameters into a map (see [Usage](#Usage)) and sets the entire map "structurally" on the task at once. An alternative approach would be eliding the map and specifying each parameter in the vars file or CredHub separately, like:

--- a/container/pipeline.yml
+++ b/container/pipeline.yml
@@ -110,6 +110,7 @@ resources:
     aws_access_key_id: ((ecr_aws_key))
     aws_secret_access_key: ((ecr_aws_secret))
     repository: ((image-repository))
+    tag: latest
     aws_region: us-gov-west-1
 
 - name: pull-request

--- a/container/pipeline.yml
+++ b/container/pipeline.yml
@@ -76,6 +76,14 @@ jobs:
         - task: cve-check
           file: common-pipelines/container/cve-check.yml
 
+    - put: image
+      inputs:
+        - image
+        - src
+      params:
+        image: image/image.tar
+        additional_tags: src/.git/short_ref
+
   on_failure:
     put: slack
     params:
@@ -95,6 +103,14 @@ resources:
     uri: https://github.com/cloud-gov/common-pipelines
     branch: main
     commit_verification_keys: ((cloud-gov-pgp-keys))
+
+- name: image
+  type: registry-image
+  source:
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: ((image-repository))
+    aws_region: us-gov-west-1
 
 - name: pull-request
   type: pull-request


### PR DESCRIPTION
## Changes proposed in this pull request:

- Push images to ECR on merge to main when audit and scan are successful
  - Tag images with git short hash (e.g. 282e38a)
- Tested successfully with `use-common-pipelines` repository in Concourse.
- Resolves https://github.com/cloud-gov/product/issues/2567

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Pushing images to our private registry is in line with the ADR and improves security.
