### PR TITLE
Make audit step output more readable by making apt operations quieter

### DIFF
--- a/container/usg-audit.sh
+++ b/container/usg-audit.sh
@@ -13,9 +13,9 @@ enable_services:
 - esm-infra
 EOF
 
-apt-get update
-apt-get -y upgrade
-apt-get -y -q install \
+apt-get -qq update
+apt-get -y -qq upgrade
+apt-get -y -qq install \
   ubuntu-advantage-tools \
   ca-certificates \
   python3-pip
@@ -23,7 +23,7 @@ apt-get -y -q install \
 echo "UA attaching"
 ua attach --attach-config ua-attach-config.yaml
 
-apt-get -y -q install usg
+apt-get -y -qq install usg
 
 echo "installing bs4"
 # Install the python library BeautifulSoup to parse html


### PR DESCRIPTION
## Changes proposed in this pull request:

- See title

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just a change to reduce logging output.