### PR TITLE
Run audit as privileged user

### DIFF
--- a/container/pipeline.yml
+++ b/container/pipeline.yml
@@ -34,6 +34,7 @@ jobs:
 
     - in_parallel:
       - task: usg-audit
+        privileged: true
         file: common-pipelines/container/usg-audit.yml
         image: image
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update audit task to run as privileged user to fix some cis failures

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Running as privileged user allows cis audit to run commands it cannot run under a namespaced user
