### PR TITLE
Parallelize all 'get' steps

### DIFF
--- a/container/pipeline-external-repository.yml
+++ b/container/pipeline-external-repository.yml
@@ -1,10 +1,11 @@
 jobs:
 - name: set-self
   plan:
-    - get: common-pipelines
-      trigger: true
-    - get: pipeline-config
-      trigger: true
+    - in_parallel:
+      - get: common-pipelines
+        trigger: true
+      - get: pipeline-config
+        trigger: true
     - set_pipeline: self
       file: common-pipelines/container/pipeline-external-repository.yml
       var_files:
@@ -12,17 +13,18 @@ jobs:
 
 - name: main
   plan:
-    - get: src
-      trigger: true
+    - in_parallel:
+      - get: src
+        trigger: true
 
-    - get: base-image
-      trigger: true
-      params:
-        format: oci
+      - get: base-image
+        trigger: true
+        params:
+          format: oci
 
-    - get: common-pipelines
-      passed: [set-self]
-      trigger: true
+      - get: common-pipelines
+        passed: [set-self]
+        trigger: true
 
     - task: oci-build
       privileged: true

--- a/container/pipeline.yml
+++ b/container/pipeline.yml
@@ -1,10 +1,11 @@
 jobs:
 - name: set-self
   plan:
-    - get: common-pipelines
-      trigger: true
-    - get: src
-      trigger: true
+    - in_parallel:
+      - get: common-pipelines
+        trigger: true
+      - get: src
+        trigger: true
     - set_pipeline: self
       file: common-pipelines/container/pipeline.yml
       var_files:
@@ -12,13 +13,14 @@ jobs:
 
 - name: pull-request
   plan:
-    - get: pull-request
-      version: every
-      trigger: true
+    - in_parallel:
+      - get: pull-request
+        version: every
+        trigger: true
 
-    - get: common-pipelines
-      passed: [set-self]
-      trigger: true
+      - get: common-pipelines
+        passed: [set-self]
+        trigger: true
 
     - put: pull-request
       params:
@@ -53,12 +55,13 @@ jobs:
 
 - name: main
   plan:
-    - get: src
-      trigger: true
+    - in_parallel:
+      - get: src
+        trigger: true
 
-    - get: common-pipelines
-      passed: [set-self]
-      trigger: true
+      - get: common-pipelines
+        passed: [set-self]
+        trigger: true
 
     - task: oci-build
       privileged: true


### PR DESCRIPTION
## Changes proposed in this pull request:

- See title

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, refactor only.
