### PR TITLE
OCI build step now requires a base image

### DIFF
--- a/container/pipeline.yml
+++ b/container/pipeline.yml
@@ -59,6 +59,11 @@ jobs:
       - get: src
         trigger: true
 
+      - get: base-image
+        trigger: true
+        params:
+          format: oci
+
       - get: common-pipelines
         passed: [set-self]
         trigger: true
@@ -100,6 +105,15 @@ jobs:
 
 
 resources:
+
+- name: base-image
+  type: registry-image
+  source:
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: ((base-image))
+    tag: ((base-image-tag))
+    aws_region: us-gov-west-1
 
 - name: common-pipelines
   type: git


### PR DESCRIPTION
## Changes proposed in this pull request:

- Get the base image resource.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.
