### PR TITLE
Add base image to PR job

### DIFF
--- a/container/pipeline.yml
+++ b/container/pipeline.yml
@@ -18,6 +18,11 @@ jobs:
         version: every
         trigger: true
 
+      - get: base-image
+        trigger: true
+        params:
+          format: oci
+
       - get: common-pipelines
         passed: [set-self]
         trigger: true


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds base image to PR job so that oci build runs

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, this just updates the pipeline to get the necessary resource
