### PR TITLE
Add tailoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,20 @@ cloud.gov maintains a variety of software written in a handful of programming la
 
 If you want to iterate on a pipeline in this repository, consider pushing your changes to a topic branch. Topic branches do not have merge protection, so you will be able to iterate more quickly without getting pull requests approved. Change your `pipeline.yml` in your downstream repository to reference your topic branch instead of `main` in the `common-pipelines` resource to continuously pull in your changes. (You can consider working on a topic branch in your downstream repo as well.)
 
+## CIS Rule Customization/Tailoring
+
+We set the following CIS Rule exceptions in our `tailor.xml` file:
+
+| Rule | Name | Reason for Exception |
+| ---- | ---- | -------------------- |
+| 1.4.3 | `xccdf_org.ssgproject.content_rule_ensure_root_password_configured` | Not applicable to containers |
+| 3.5.2.9 | `xccdf_org.ssgproject.content_rule_service_nftables_enabled` | False Positive: nftables is enabled |
+| 3.5.2.8 | `xccdf_org.ssgproject.content_rule_nftables_ensure_default_deny_policy` | Not applicable to containers, needs privileged access |
+| 3.5.2.10 | `xccdf_org.ssgproject.content_rule_nftables_rules_permanent`| Not applicable to containers, needs privileged access |
+| 3.5.2.5 | `xccdf_org.ssgproject.content_rule_set_nftables_base_chain` | Not applicable to containers, needs privileged access |
+| 3.5.2.6 | `xccdf_org.ssgproject.content_rule_set_nftables_loopback_traffic` | Not applicable to containers, needs privileged access |
+| 3.5.2.4 | `xccdf_org.ssgproject.content_rule_set_nftables_tablev` | Not applicable to containers, needs privileged access |
+
 ## Troubleshooting
 
 ### Pipeline archived after bootstrap

--- a/README.md
+++ b/README.md
@@ -62,15 +62,15 @@ If you want to iterate on a pipeline in this repository, consider pushing your c
 
 We set the following CIS Rule exceptions in our `tailor.xml` file:
 
-| Rule | Name | Reason for Exception |
-| ---- | ---- | -------------------- |
-| 1.4.3 | `xccdf_org.ssgproject.content_rule_ensure_root_password_configured` | Not applicable to containers |
-| 3.5.2.9 | `xccdf_org.ssgproject.content_rule_service_nftables_enabled` | False Positive: nftables is enabled |
-| 3.5.2.8 | `xccdf_org.ssgproject.content_rule_nftables_ensure_default_deny_policy` | Not applicable to containers, needs privileged access |
-| 3.5.2.10 | `xccdf_org.ssgproject.content_rule_nftables_rules_permanent`| Not applicable to containers, needs privileged access |
-| 3.5.2.5 | `xccdf_org.ssgproject.content_rule_set_nftables_base_chain` | Not applicable to containers, needs privileged access |
-| 3.5.2.6 | `xccdf_org.ssgproject.content_rule_set_nftables_loopback_traffic` | Not applicable to containers, needs privileged access |
-| 3.5.2.4 | `xccdf_org.ssgproject.content_rule_set_nftables_tablev` | Not applicable to containers, needs privileged access |
+| Rule | Name | Reason for Exception | How to Confirm |
+| ---- | ---- | -------------------- | -------------- |
+| 1.4.3 | `xccdf_org.ssgproject.content_rule_ensure_root_password_configured` | Not applicable to concourse containers | Check out documentation on [concourse internals](https://concourse-ci.org/internals.html) and [fly intercept](https://concourse-ci.org/builds.html#fly-intercept) |
+| 3.5.2.9 | `xccdf_org.ssgproject.content_rule_service_nftables_enabled` | False Positive: nftables is enabled | Run `systemctl is-enabled nftables` |
+| 3.5.2.8 | `xccdf_org.ssgproject.content_rule_nftables_ensure_default_deny_policy` | Not applicable to containers, needs privileged access | Run any nftables command, like `nft list ruleset` to see that the operation is not permitted |
+| 3.5.2.10 | `xccdf_org.ssgproject.content_rule_nftables_rules_permanent`| Not applicable to containers, needs privileged access | Run any nftables command, like `nft list ruleset` to see that the operation is not permitted |
+| 3.5.2.5 | `xccdf_org.ssgproject.content_rule_set_nftables_base_chain` | Not applicable to containers, needs privileged access | Run any nftables command, like `nft list ruleset` to see that the operation is not permitted |
+| 3.5.2.6 | `xccdf_org.ssgproject.content_rule_set_nftables_loopback_traffic` | Not applicable to containers, needs privileged access | Run any nftables command, like `nft list ruleset` to see that the operation is not permitted |
+| 3.5.2.4 | `xccdf_org.ssgproject.content_rule_set_nftables_table` | Not applicable to containers, needs privileged access | Run any nftables command, like `nft list ruleset` to see that the operation is not permitted |
 
 ## Troubleshooting
 

--- a/container/tailor.xml
+++ b/container/tailor.xml
@@ -1,0 +1,545 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
+  <benchmark href="/usr/share/ubuntu-scap-security-guides/1/benchmarks/ssg-ubuntu2204-xccdf.xml"/>
+  <version time="2023-06-07T15:29:53">1</version>
+  <Profile id="xccdf_org.ssgproject.content_profile_cis_level1_server_customized" extends="xccdf_org.ssgproject.content_profile_cis_level1_server">
+    <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 22.04 Level 1 Server Benchmark [CUSTOMIZED]</title>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 22.04 LTS Benchmark, v1.0.0, released 08-30-2022.</description>
+    <!--1.1.1.1 Ensure mounting of cramfs filesystems is disabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_kernel_module_cramfs_disabled" selected="true"/>
+    <!--1.1.2.1 Ensure /tmp is a separate partition (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_partition_for_tmp" selected="true"/>
+    <!--1.1.2.2 Ensure nodev option set on /tmp partition (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_mount_option_tmp_nodev" selected="true"/>
+    <!--1.1.2.3 Ensure noexec option set on /tmp partition (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_mount_option_tmp_noexec" selected="true"/>
+    <!--1.1.2.4 Ensure nosuid option set on /tmp partition (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_mount_option_tmp_nosuid" selected="true"/>
+    <!--1.1.3.2 Ensure nodev option set on /var partition (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_mount_option_var_nodev" selected="true"/>
+    <!--1.1.3.3 Ensure nosuid option set on /var partition (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_mount_option_var_nosuid" selected="true"/>
+    <!--1.1.4.2 Ensure noexec option set on /var/tmp partition (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_mount_option_var_tmp_noexec" selected="true"/>
+    <!--1.1.4.3 Ensure nosuid option set on /var/tmp partition (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_mount_option_var_tmp_nosuid" selected="true"/>
+    <!--1.1.4.4 Ensure nodev option set on /var/tmp partition (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_mount_option_var_tmp_nodev" selected="true"/>
+    <!--1.1.5.2 Ensure nodev option set on /var/log partition (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_mount_option_var_log_nodev" selected="true"/>
+    <!--1.1.5.3 Ensure noexec option set on /var/log partition (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_mount_option_var_log_noexec" selected="true"/>
+    <!--1.1.5.4 Ensure nosuid option set on /var/log partition (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_mount_option_var_log_nosuid" selected="true"/>
+    <!--1.1.6.2 Ensure noexec option set on /var/log/audit partition (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_mount_option_var_log_audit_noexec" selected="true"/>
+    <!--1.1.6.3 Ensure nodev option set on /var/log/audit partition (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_mount_option_var_log_audit_nodev" selected="true"/>
+    <!--1.1.6.4 Ensure nosuid option set on /var/log/audit partition (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_mount_option_var_log_audit_nosuid" selected="true"/>
+    <!--1.1.7.2 Ensure nodev option set on /home partition (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_mount_option_home_nodev" selected="true"/>
+    <!--1.1.7.2 Ensure nosuid option set on /home partition (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_mount_option_home_nosuid" selected="true"/>
+    <!--1.1.8.1 Ensure nodev option set on /dev/shm partition (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_mount_option_dev_shm_nodev" selected="true"/>
+    <!--1.1.8.2 Ensure noexec option set on /dev/shm partition (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_mount_option_dev_shm_noexec" selected="true"/>
+    <!--1.1.8.3 Ensure nosuid option set on /dev/shm partition (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_mount_option_dev_shm_nosuid" selected="true"/>
+    <!--1.1.9 Disable Automounting (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_service_autofs_disabled" selected="true"/>
+    <!--1.1.10 Disable USB Storage (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_kernel_module_usb-storage_disabled" selected="true"/>
+    <!--1.3.1 Ensure AIDE is installed (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_aide_installed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_aide_build_database" selected="true"/>
+    <!--1.3.2 Ensure filesystem integrity is regularly checked (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_aide_periodic_cron_checking" selected="true"/>
+    <!--1.4.1 Ensure bootloader password is set (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_grub2_password" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_grub2_uefi_password" selected="true"/>
+    <!--1.4.2 Ensure permissions on bootloader config are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_grub2_cfg" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_grub2_cfg" selected="true"/>
+    <!--1.4.3 Ensure authentication required for single user mode (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_ensure_root_password_configured" selected="false"/>
+    <!--1.5.1 Ensure address space layout randomization (ASLR) is enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_kernel_randomize_va_space" selected="true"/>
+    <!--1.5.2 Ensure prelink is disabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_prelink_removed" selected="true"/>
+    <!--1.5.3 Ensure Automatic Error Reporting is not enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_service_apport_disabled" selected="true"/>
+    <!--1.5.4 Ensure core dumps are restricted (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_disable_users_coredumps" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_fs_suid_dumpable" selected="true"/>
+    <!--1.6.1.1 Ensure AppArmor is installed (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_apparmor_installed" selected="true"/>
+    <!--1.6.1.2 Ensure AppArmor is enabled in the bootloader configuration (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_grub2_enable_apparmor" selected="true"/>
+    <!--1.6.1.3 Ensure all AppArmor Profiles are in enforce or complain mode (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_apparmor_mode">complain</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_all_apparmor_profiles_in_enforce_complain_mode" selected="true"/>
+    <!--1.7.1 Ensure message of the day is configured properly (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_login_banner_text">^Authorized[\s\n]+uses[\s\n]+only\.[\s\n]+All[\s\n]+activity[\s\n]+may[\s\n]+be[\s\n]+monitored[\s\n]+and[\s\n]+reported\.$</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_banner_etc_motd" selected="true"/>
+    <!--1.7.2 Ensure local login warning banner is configured properly (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_banner_etc_issue" selected="true"/>
+    <!--1.7.3 Ensure remote login warning banner is configured properly (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_banner_etc_issue_net" selected="true"/>
+    <!--1.7.4 Ensure permissions on /etc/motd are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_motd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_motd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_motd" selected="true"/>
+    <!--1.7.5 Ensure permissions on /etc/issue are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_issue" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_issue" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_issue" selected="true"/>
+    <!--1.7.6 Ensure permissions on /etc/issue.net are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_issue_net" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_issue_net" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_issue_net" selected="true"/>
+    <!--1.8.2 Ensure GDM login banner is configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_banner_enabled" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_login_banner_text" selected="true"/>
+    <!--1.8.3 Ensure GDM disable-user-list option is enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_disable_user_list" selected="true"/>
+    <!--1.8.4 Ensure GDM screen locks when the user is idle (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_screensaver_lock_enabled" selected="true"/>
+    <!--1.8.5 Ensure GDM screen locks cannot be overridden (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_screensaver_lock_delay" selected="true"/>
+    <!--1.8.6 Ensure GDM automatic mounting of removable media is disabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_disable_automount" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_disable_automount_open" selected="true"/>
+    <!--1.8.8 Ensure GDM autorun-never is enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_disable_autorun" selected="true"/>
+    <!--1.8.10 Ensure XDCMP is not enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_gnome_gdm_disable_xdmcp" selected="true"/>
+    <!--2.1.1.1 Ensure a single time synchronization is in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_chrony_installed" selected="false"/>
+    <select idref="xccdf_org.ssgproject.content_rule_package_ntp_installed" selected="false"/>
+    <select idref="xccdf_org.ssgproject.content_rule_package_timesyncd_installed" selected="true"/>
+    <!--2.1.2.2 Ensure chrony is running as user _chrony (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_chronyd_run_as_chrony_user" selected="true"/>
+    <!--2.1.2.3 Ensure chrony is enabled and running (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_service_chronyd_enabled" selected="true"/>
+    <!--2.1.3.2 Ensure systemd-timesyncd is enabled and running (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_service_timesyncd_enabled" selected="true"/>
+    <!--2.1.4.1 Ensure ntp access control is configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_ntpd_configure_restrictions" selected="true"/>
+    <!--2.1.4.3 Ensure ntp is running as user ntp (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_ntpd_run_as_ntp_user" selected="true"/>
+    <!--2.1.4.4 Ensure ntp is enabled and running (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_service_ntp_enabled" selected="true"/>
+    <!--2.2.1 Ensure X Window System is not installed (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_xorg-x11-server-common_removed" selected="true"/>
+    <!--2.2.2 Ensure Avahi Server is not installed (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_service_avahi-daemon_disabled" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_package_avahi_removed" selected="true"/>
+    <!--2.2.3 Ensure CUPS is not installed (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_service_cups_disabled" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_package_cups_removed" selected="true"/>
+    <!--2.2.4 Ensure DHCP Server is not installed (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dhcp_removed" selected="true"/>
+    <!--2.2.5 Ensure LDAP server is not installed (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_openldap-servers_removed" selected="true"/>
+    <!--2.2.6 Ensure NFS is not installed (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_nfs-kernel-server_removed" selected="true"/>
+    <!--2.2.7 Ensure DNS Server is not installed (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_bind_removed" selected="true"/>
+    <!--2.2.8 Ensure FTP Server is not installed (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_vsftpd_removed" selected="true"/>
+    <!--2.2.9 Ensure HTTP server is not installed (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_httpd_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_package_nginx_removed" selected="true"/>
+    <!--2.2.10 Ensure IMAP and POP3 server are not installed (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dovecot_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_package_cyrus-imapd_removed" selected="true"/>
+    <!--2.2.11 Ensure Samba is not installed (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_samba_removed" selected="true"/>
+    <!--2.2.12 Ensure HTTP Proxy Server is not installed (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_squid_removed" selected="true"/>
+    <!--2.2.13 Ensure SNMP Server is not installed (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_net-snmp_removed" selected="true"/>
+    <!--2.2.14 Ensure NIS Server is not installed (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_nis_removed" selected="true"/>
+    <!--2.2.15 Ensure mail transfer agent is configured for local-only mode (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_postfix_inet_interfaces">loopback-only</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_postfix_network_listening_disabled" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_has_nonlocal_mta" selected="true"/>
+    <!--2.2.16 Ensure rsync service is not installed (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_rsync_removed" selected="true"/>
+    <!--2.3.2 Ensure rsh client is not installed (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_rsh_removed" selected="true"/>
+    <!--2.3.3 Ensure talk client is not installed (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_talk_removed" selected="true"/>
+    <!--2.3.4 Ensure telnet client is not installed (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_telnet_removed" selected="true"/>
+    <!--2.3.5 Ensure LDAP client is not installed (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_openldap-clients_removed" selected="true"/>
+    <!--2.3.6 Ensure RPC is not installed (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_rpcbind_removed" selected="true"/>
+    <!--3.1.2 Ensure wireless interfaces are disabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_wireless_disable_interfaces" selected="true"/>
+    <!--3.2.1 Ensure packet redirect sending is disabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_send_redirects" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_send_redirects" selected="true"/>
+    <!--3.2.2 Ensure IP forwarding is disabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_ip_forward" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_forwarding" selected="true"/>
+    <!--3.3.1 Ensure source routed packets are not accepted (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_accept_source_route" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_accept_source_route" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_accept_source_route" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_default_accept_source_route" selected="true"/>
+    <!--3.3.2 Ensure ICMP redirects are not accepted (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_accept_redirects" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_accept_redirects" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_accept_redirects" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_default_accept_redirects" selected="true"/>
+    <!--3.3.3 Ensure secure ICMP redirects are not accepted (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_secure_redirects" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_secure_redirects" selected="true"/>
+    <!--3.3.4 Ensure suspicious packets are logged (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_log_martians" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_log_martians" selected="true"/>
+    <!--3.3.5 Ensure broadcast ICMP requests are ignored (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_icmp_echo_ignore_broadcasts" selected="true"/>
+    <!--3.3.6 Ensure bogus ICMP responses are ignored (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_icmp_ignore_bogus_error_responses" selected="true"/>
+    <!--3.3.7 Ensure Reverse Path Filtering is enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_rp_filter" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_rp_filter" selected="true"/>
+    <!--3.3.8 Ensure TCP SYN Cookies is enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_tcp_syncookies" selected="true"/>
+    <!--3.3.9 Ensure IPv6 router advertisements are not accepted (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_accept_ra" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_default_accept_ra" selected="true"/>
+    <!--3.5.1.1 Ensure ufw is installed (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_ufw_installed" selected="false"/>
+    <!--3.5.1.2 Ensure iptables-persistent is not installed with ufw (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_iptables-persistent_removed" selected="true"/>
+    <!--3.5.1.3 Ensure ufw service is enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_service_ufw_enabled" selected="true"/>
+    <!--3.5.1.4 Ensure ufw loopback traffic is configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_set_ufw_loopback_traffic" selected="true"/>
+    <!--3.5.1.6 Ensure ufw firewall rules exist for all open ports (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_ufw_rules_for_open_ports" selected="true"/>
+    <!--3.5.1.7 Ensure ufw default deny firewall policy (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_set_ufw_default_rule" selected="true"/>
+    <!--3.5.2.1 Ensure nftables is installed (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_nftables_installed" selected="true"/>
+    <!--3.5.2.2 Ensure ufw is uninstalled or disabled with nftables (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_ufw_removed" selected="true"/>
+    <!--3.5.2.4 Ensure a nftables table exists (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_nftables_family">inet</set-value>
+    <set-value idref="xccdf_org.ssgproject.content_value_var_nftables_table">filter</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_set_nftables_table" selected="false"/>
+    <!--3.5.2.5 Ensure nftables base chains exist (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_set_nftables_base_chain" selected="false"/>
+    <!--3.5.2.6 Ensure nftables loopback traffic is configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_set_nftables_loopback_traffic" selected="false"/>
+    <!--3.5.2.8 Ensure nftables default deny firewall policy (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_nftables_ensure_default_deny_policy" selected="false"/>
+    <!--3.5.2.9 Ensure nftables service is enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_service_nftables_enabled" selected="false"/>
+    <!--3.5.2.10 Ensure nftables rules are permanent (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_nftable_master_config_file">/etc/nftables.conf</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_nftables_rules_permanent" selected="false"/>
+    <!--3.5.3.1.1 Ensure iptables packages are installed (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_iptables_installed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_package_iptables-persistent_installed" selected="false"/>
+    <!--3.5.3.1.2 Ensure nftables is not installed with iptables (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_service_nftables_disabled" selected="false"/>
+    <select idref="xccdf_org.ssgproject.content_rule_package_nftables_removed" selected="false"/>
+    <!--3.5.3.2.1 Ensure iptables default deny firewall policy (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_set_iptables_default_rule" selected="true"/>
+    <!--3.5.3.2.2 Ensure iptables loopback traffic is configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_set_loopback_traffic" selected="true"/>
+    <!--3.5.3.2.4 Ensure iptables firewall rules exist for all open ports (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_iptables_rules_for_open_ports" selected="true"/>
+    <!--3.5.3.3.1 Ensure ip6tables default deny firewall policy (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_set_ip6tables_default_rule" selected="true"/>
+    <!--3.5.3.3.2 Ensure ip6tables loopback traffic is configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_set_ipv6_loopback_traffic" selected="true"/>
+    <!--3.5.3.3.4 Ensure ip6tables firewall rules exist for all open ports (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_ip6tables_rules_for_open_ports" selected="true"/>
+    <!--4.1.4.1 Ensure audit log files are mode 0640 or less permissive (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_var_log_audit" selected="true"/>
+    <!--4.1.4.2 Ensure only authorized users own audit log files (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_ownership_var_log_audit_stig" selected="true"/>
+    <!--4.1.4.3 Ensure only authorized groups are assigned ownership of audit log files (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_group_ownership_var_log_audit" selected="true"/>
+    <!--4.1.4.4 Ensure the audit log directory is 0750 or more restrictive (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_directory_permissions_var_log_audit" selected="true"/>
+    <!--4.1.4.5 Ensure audit configuration files are 640 or more restrictive (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_audit_rulesd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_audit_auditd" selected="true"/>
+    <!--4.1.4.6 Ensure audit configuration files are owned by root (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_ownership_audit_configuration" selected="true"/>
+    <!--4.1.4.7 Ensure audit configuration files belong to group root (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupownership_audit_configuration" selected="true"/>
+    <!--4.1.4.8 Ensure audit tools are 755 or more restrictive (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_audit_binaries" selected="true"/>
+    <!--4.1.4.9 Ensure audit tools are owned by root (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_ownership_audit_binaries" selected="true"/>
+    <!--4.1.4.10 Ensure audit tools belong to group root (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupownership_audit_binaries" selected="true"/>
+    <!--4.1.4.11 Ensure cryptographic mechanisms are used to protect the integrity of audit tools (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_aide_check_audit_tools" selected="true"/>
+    <!--4.2.1.1.1 Ensure systemd-journal-remote is installed (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_systemd-journal-remote_installed" selected="true"/>
+    <!--4.2.1.1.4 Ensure journald is not configured to receive logs from a remote client (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_socket_systemd-journal-remote_disabled" selected="true"/>
+    <!--4.2.1.2 Ensure journald service is enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_service_systemd-journald_enabled" selected="true"/>
+    <!--4.2.1.3 Ensure journald is configured to compress large log files (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_journald_compress" selected="true"/>
+    <!--4.2.1.4 Ensure journald is configured to write logfiles to persistent disk (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_journald_storage" selected="true"/>
+    <!--4.2.2.1 Ensure rsyslog is installed (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_rsyslog_installed" selected="true"/>
+    <!--4.2.2.2 Ensure rsyslog service is enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_service_rsyslog_enabled" selected="true"/>
+    <!--4.2.2.4 Ensure rsyslog default file permissions are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_rsyslog_filecreatemode" selected="true"/>
+    <!--4.2.2.6 Ensure rsyslog is configured to send logs to a remote log host (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_rsyslog_remote_loghost" selected="true"/>
+    <!--4.2.2.7 Ensure rsyslog is not configured to receive logs from a remote client (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_rsyslog_nolisten" selected="true"/>
+    <!--4.2.3 Ensure all logfiles have appropriate permissions and ownership (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_permissions_local_var_log" selected="true"/>
+    <!--5.1.1 Ensure cron daemon is enabled and running (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_service_cron_enabled" selected="true"/>
+    <!--5.1.2 Ensure permissions on /etc/crontab are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_crontab" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_crontab" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_crontab" selected="true"/>
+    <!--5.1.3 Ensure permissions on /etc/cron.hourly are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_cron_hourly" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_cron_hourly" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_cron_hourly" selected="true"/>
+    <!--5.1.4 Ensure permissions on /etc/cron.daily are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_cron_daily" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_cron_daily" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_cron_daily" selected="true"/>
+    <!--5.1.5 Ensure permissions on /etc/cron.weekly are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_cron_weekly" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_cron_weekly" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_cron_weekly" selected="true"/>
+    <!--5.1.6 Ensure permissions on /etc/cron.monthly are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_cron_monthly" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_cron_monthly" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_cron_monthly" selected="true"/>
+    <!--5.1.7 Ensure permissions on /etc/cron.d are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_cron_d" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_cron_d" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_cron_d" selected="true"/>
+    <!--5.1.8 Ensure cron is restricted to authorized users (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_cron_deny_not_exist" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_cron_allow" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_cron_allow" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_cron_allow" selected="true"/>
+    <!--5.1.9 Ensure at is restricted to authorized users (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_at_deny_not_exist" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_at_allow" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_at_allow" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_at_allow" selected="true"/>
+    <!--5.2.1 Ensure permissions on /etc/ssh/sshd_config are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_config" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_sshd_config" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_sshd_config" selected="true"/>
+    <!--5.2.2 Ensure permissions on SSH private host key files are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key" selected="true"/>
+    <!--5.2.3 Ensure permissions on SSH public host key files are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_pub_key" selected="true"/>
+    <!--5.2.4 Ensure SSH access is limited (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_limit_user_access" selected="true"/>
+    <!--5.2.5 Ensure SSH LogLevel is appropriate (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_loglevel_info" selected="true"/>
+    <!--5.2.6 Ensure SSH PAM is enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_pam" selected="true"/>
+    <!--5.2.7 Ensure SSH root login is disabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_root_login" selected="true"/>
+    <!--5.2.8 Ensure SSH HostbasedAuthentication is disabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_disable_host_auth" selected="true"/>
+    <!--5.2.9 Ensure SSH PermitEmptyPasswords is disabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_empty_passwords" selected="true"/>
+    <!--5.2.10 Ensure SSH PermitUserEnvironment is disabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_do_not_permit_user_env" selected="true"/>
+    <!--5.2.11 Ensure SSH IgnoreRhosts is enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_rhosts" selected="true"/>
+    <!--5.2.13 Ensure only strong Ciphers are used (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_use_strong_ciphers" selected="true"/>
+    <!--5.2.14 Ensure only strong MAC algorithms are used (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_use_strong_macs" selected="true"/>
+    <!--5.2.15 Ensure only strong Key Exchange algorithms are used (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_sshd_strong_kex">ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_use_strong_kex" selected="true"/>
+    <!--5.2.17 Ensure SSH warning banner is configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_warning_banner_net" selected="true"/>
+    <!--5.2.18 Ensure SSH MaxAuthTries is set to 4 or less (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_sshd_max_auth_tries_value">4</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_max_auth_tries" selected="true"/>
+    <!--5.2.19 Ensure SSH MaxStartups is configured (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_sshd_set_maxstartups">10:30:60</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_maxstartups" selected="true"/>
+    <!--5.2.20 Ensure SSH MaxSessions is set to 10 or less (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_sshd_max_sessions">10</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_max_sessions" selected="true"/>
+    <!--5.2.21 Ensure SSH LoginGraceTime is set to one minute or less (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_sshd_set_login_grace_time">60</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_login_grace_time" selected="true"/>
+    <!--5.2.22 Ensure SSH Idle Timeout Interval is configured (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_sshd_idle_timeout_value">300</set-value>
+    <set-value idref="xccdf_org.ssgproject.content_value_var_sshd_set_keepalive">3</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_idle_timeout" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_keepalive" selected="true"/>
+    <!--5.3.1 Ensure sudo is installed (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_sudo_installed" selected="true"/>
+    <!--5.3.2 Ensure sudo commands use pty (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sudo_add_use_pty" selected="true"/>
+    <!--5.3.3 Ensure sudo log file exists (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sudo_custom_logfile" selected="true"/>
+    <!--5.3.5 Ensure re-authentication for privilege escalation is not disabled globally (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sudo_remove_no_authenticate" selected="true"/>
+    <!--5.3.6 Ensure sudo authentication timeout is configured correctly (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_sudo_timestamp_timeout">15</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_sudo_require_reauthentication" selected="true"/>
+    <!--5.3.7 Ensure access to the su command is restricted (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_pam_wheel_group_for_su">sugroup</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_use_pam_wheel_group_for_su" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_ensure_pam_wheel_group_empty" selected="true"/>
+    <!--5.4.1 Ensure password creation requirements are configured (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_password_pam_minlen">14</set-value>
+    <set-value idref="xccdf_org.ssgproject.content_value_var_password_pam_minclass">4</set-value>
+    <set-value idref="xccdf_org.ssgproject.content_value_var_password_pam_dcredit">-1</set-value>
+    <set-value idref="xccdf_org.ssgproject.content_value_var_password_pam_ucredit">-1</set-value>
+    <set-value idref="xccdf_org.ssgproject.content_value_var_password_pam_ocredit">-1</set-value>
+    <set-value idref="xccdf_org.ssgproject.content_value_var_password_pam_lcredit">-1</set-value>
+    <set-value idref="xccdf_org.ssgproject.content_value_var_password_pam_retry">3</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_password_pam_minlen" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_password_pam_minclass" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_password_pam_dcredit" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_password_pam_ucredit" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_password_pam_ocredit" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_password_pam_lcredit" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_password_pam_retry" selected="true"/>
+    <!--5.4.2 Ensure lockout for failed password attempts is configured (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_accounts_passwords_pam_faillock_deny">4</set-value>
+    <set-value idref="xccdf_org.ssgproject.content_value_var_accounts_passwords_pam_faillock_fail_interval">900</set-value>
+    <set-value idref="xccdf_org.ssgproject.content_value_var_accounts_passwords_pam_faillock_unlock_time">600</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_passwords_pam_faillock_deny" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_passwords_pam_faillock_interval" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_passwords_pam_faillock_unlock_time" selected="true"/>
+    <!--5.4.3 Ensure password reuse is limited (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_password_pam_remember">5</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_password_pam_unix_remember" selected="true"/>
+    <!--5.4.4 Ensure password hashing algorithm is up to date with the latest standards (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_password_hashing_algorithm">yescrypt</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_set_password_hashing_algorithm_logindefs" selected="true"/>
+    <!--5.5.1.1 Ensure minimum days between password changes is configured (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_accounts_minimum_age_login_defs">1</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_minimum_age_login_defs" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_password_set_min_life_existing" selected="true"/>
+    <!--5.5.1.2 Ensure password expiration is 365 days or less (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_accounts_maximum_age_login_defs">365</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_maximum_age_login_defs" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_password_set_max_life_existing" selected="true"/>
+    <!--5.5.1.3 Ensure password expiration warning days is 7 or more (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_accounts_password_warn_age_login_defs">7</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_password_warn_age_login_defs" selected="true"/>
+    <!--5.5.1.4 Ensure inactive password lock is 30 days or less (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_account_disable_post_pw_expiration">30</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_account_disable_post_pw_expiration" selected="true"/>
+    <!--5.5.1.5 Ensure all users last password change date is in the past (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_password_last_change_is_in_past" selected="true"/>
+    <!--5.5.2 Ensure system accounts are secured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_no_shelllogin_for_systemaccounts" selected="true"/>
+    <!--5.5.3 Ensure default group for the root account is GID 0 (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_root_gid_zero" selected="true"/>
+    <!--5.5.4 Ensure default user umask is 027 or more restrictive (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_accounts_user_umask">027</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_umask_etc_login_defs" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_umask_etc_profile" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_umask_etc_bashrc" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_umask_interactive_users" selected="true"/>
+    <!--5.5.5 Ensure default user shell timeout is 900 seconds or less (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_accounts_tmout">900</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_tmout" selected="true"/>
+    <!--6.1.1 Ensure permissions on /etc/passwd are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_passwd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_passwd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_passwd" selected="true"/>
+    <!--6.1.2 Ensure permissions on /etc/passwd- are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_backup_etc_passwd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_backup_etc_passwd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_backup_etc_passwd" selected="true"/>
+    <!--6.1.3 Ensure permissions on /etc/group are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_group" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_group" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_group" selected="true"/>
+    <!--6.1.4 Ensure permissions on /etc/group- are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_backup_etc_group" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_backup_etc_group" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_backup_etc_group" selected="true"/>
+    <!--6.1.5 Ensure permissions on /etc/shadow are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_shadow" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_shadow" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_shadow" selected="true"/>
+    <!--6.1.6 Ensure permissions on /etc/shadow- are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_backup_etc_shadow" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_backup_etc_shadow" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_backup_etc_shadow" selected="true"/>
+    <!--6.1.7 Ensure permissions on /etc/gshadow are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_gshadow" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_gshadow" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_gshadow" selected="true"/>
+    <!--6.1.8 Ensure permissions on /etc/gshadow- are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_backup_etc_gshadow" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_backup_etc_gshadow" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_backup_etc_gshadow" selected="true"/>
+    <!--6.1.9 Ensure no world writable files exist (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_unauthorized_world_writable" selected="true"/>
+    <!--6.1.10 Ensure no unowned files or directories exist (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_no_files_unowned_by_user" selected="true"/>
+    <!--6.1.11 Ensure no ungrouped files or directories exist (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned" selected="true"/>
+    <!--6.2.1 Ensure accounts in /etc/passwd use shadowed passwords (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_password_all_shadowed" selected="true"/>
+    <!--6.2.2 Ensure /etc/shadow password fields are not empty (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_no_empty_passwords_etc_shadow" selected="true"/>
+    <!--6.2.3 Ensure all groups in /etc/passwd exist in /etc/group (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_gid_passwd_group_same" selected="true"/>
+    <!--6.2.4 Ensure shadow group is empty (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_ensure_shadow_group_empty" selected="true"/>
+    <!--6.2.5 Ensure no duplicate UIDs exist (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_account_unique_id" selected="true"/>
+    <!--6.2.6 Ensure no duplicate GIDs exist (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_group_unique_id" selected="true"/>
+    <!--6.2.7 Ensure no duplicate user names exist (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_account_unique_name" selected="true"/>
+    <!--6.2.8 Ensure no duplicate group names exist (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_group_unique_name" selected="true"/>
+    <!--6.2.9 Ensure root PATH Integrity (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_root_path_dirs_no_write" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_root_path_no_dot" selected="true"/>
+    <!--6.2.10 Ensure root is the only UID 0 account (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_no_uid_except_zero" selected="true"/>
+    <!--6.2.11 Ensure local interactive user home directories exist (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_interactive_home_directory_exists" selected="true"/>
+    <!--6.2.12 Ensure local interactive users own their home directories (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_ownership_home_directories" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupownership_home_directories" selected="true"/>
+    <!--6.2.13 Ensure users' home directories permissions are 750 or more restrictive (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_home_directories" selected="true"/>
+    <!--6.2.14 Ensure no local interactive user has .netrc files (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_no_netrc_files" selected="true"/>
+    <!--6.2.16 Ensure no users have .rhosts files (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_no_rsh_trust_files" selected="true"/>
+    <!--6.2.17 Ensure local interactive user dot files are not group or world writable (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_no_world_writable_programs" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_group_ownership" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_user_ownership" selected="true"/>
+  </Profile>
+</Tailoring>

--- a/container/usg-audit.sh
+++ b/container/usg-audit.sh
@@ -31,7 +31,7 @@ pip3 install beautifulsoup4
 
 # Run cis audit and put html results into cis-audit.html file
 echo "running audit"
-usg audit --tailoring-file tailor.xml --html-file $PWD/audit/cis-audit.html --results-file $PWD/audit/cis-audit.xml
+usg audit --tailoring-file common-pipelines/container/tailor.xml --html-file $PWD/audit/cis-audit.html --results-file $PWD/audit/cis-audit.xml
 
 # Parse the resulting cis-audit.html file looking for pass/fail via a python script
 if [ "$(./common-pipelines/container/parse_cis_audit_html.py --inputfile audit/cis-audit.html)" == "failed" ]

--- a/container/usg-audit.sh
+++ b/container/usg-audit.sh
@@ -31,7 +31,7 @@ pip3 install beautifulsoup4
 
 # Run cis audit and put html results into cis-audit.html file
 echo "running audit"
-usg audit cis_level1_server --html-file $PWD/audit/cis-audit.html --results-file $PWD/audit/cis-audit.xml
+usg audit --tailoring-file tailor.xml --html-file $PWD/audit/cis-audit.html --results-file $PWD/audit/cis-audit.xml
 
 # Parse the resulting cis-audit.html file looking for pass/fail via a python script
 if [ "$(./common-pipelines/container/parse_cis_audit_html.py --inputfile audit/cis-audit.html)" == "failed" ]


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds tailoring file to customize CIS Audit
- Updates usg audit command to use tailoring file

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

The tailoring file is a list of rules generated by the usg command that anyone can get if they make a ubuntu pro account. The only reason why we change a rule from true to false is if it is something that doesn't apply to our configuration, so it isn't opening up or advertising any vulnerabilities.
