### PR TITLE
Add exception to tailoring file

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ We set the following CIS Rule exceptions in our `tailor.xml` file:
 | 3.5.2.5 | `xccdf_org.ssgproject.content_rule_set_nftables_base_chain` | Not applicable to containers, needs privileged access | Run any nftables command, like `nft list ruleset` to see that the operation is not permitted |
 | 3.5.2.6 | `xccdf_org.ssgproject.content_rule_set_nftables_loopback_traffic` | Not applicable to containers, needs privileged access | Run any nftables command, like `nft list ruleset` to see that the operation is not permitted |
 | 3.5.2.4 | `xccdf_org.ssgproject.content_rule_set_nftables_table` | Not applicable to containers, needs privileged access | Run any nftables command, like `nft list ruleset` to see that the operation is not permitted |
+| 4.2.3 | `xccdf_org.ssgproject.content_rule_permissions_local_var_log` | Triggers on apt log files causing a false positive | Apt log permissions are set this way [by design](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=285551)
 
 ## Troubleshooting
 

--- a/container/tailor.xml
+++ b/container/tailor.xml
@@ -308,7 +308,7 @@
     <!--4.2.2.7 Ensure rsyslog is not configured to receive logs from a remote client (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_rsyslog_nolisten" selected="true"/>
     <!--4.2.3 Ensure all logfiles have appropriate permissions and ownership (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_permissions_local_var_log" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_permissions_local_var_log" selected="false"/>
     <!--5.1.1 Ensure cron daemon is enabled and running (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_service_cron_enabled" selected="true"/>
     <!--5.1.2 Ensure permissions on /etc/crontab are configured (Automated)-->


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updates tailoring file to account for log rule
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

This ignores the rule checking for log permissions of a certain level in /var/logs. Apt logs have been set to a different permission level by design, thus causing issues with this rule.
