### PR TITLE
Add continuous scanning

### DIFF
--- a/container/pipeline-external-repository.yml
+++ b/container/pipeline-external-repository.yml
@@ -136,7 +136,7 @@ resources:
 - name: every-30-days
   type: time
   source:
-    interval: 30d
+    interval: 720h
 
 resource_types:
 - name: slack-notification

--- a/container/pipeline-external-repository.yml
+++ b/container/pipeline-external-repository.yml
@@ -51,9 +51,6 @@ jobs:
 - name: continuous-scan
   plan:
     - in_parallel:
-      - get: src
-        trigger: false
-
       - get: image
         trigger: false
         params:
@@ -62,7 +59,7 @@ jobs:
       - get: common-pipelines
         trigger: false
 
-      - get: every-30-days
+      - get: daily
         trigger: true
 
     - in_parallel:
@@ -133,10 +130,10 @@ resources:
     branch: ((src-target-branch))
     # Since src is a repo outside the cloud-gov org, don't verify commits.
 
-- name: every-30-days
+- name: daily
   type: time
   source:
-    interval: 720h
+    interval: 24h
 
 resource_types:
 - name: slack-notification

--- a/container/pipeline-external-repository.yml
+++ b/container/pipeline-external-repository.yml
@@ -109,7 +109,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/common-pipelines
-    branch: continuous-scanning
+    branch: main
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
 - name: image

--- a/container/pipeline-external-repository.yml
+++ b/container/pipeline-external-repository.yml
@@ -62,7 +62,7 @@ jobs:
       - get: common-pipelines
         trigger: false
 
-      - get: monthly
+      - get: every-30-days
         trigger: true
 
     - in_parallel:
@@ -109,7 +109,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/common-pipelines
-    branch: main
+    branch: continuous-scanning
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
 - name: image
@@ -133,20 +133,13 @@ resources:
     branch: ((src-target-branch))
     # Since src is a repo outside the cloud-gov org, don't verify commits.
 
-- name: monthly
-  type: cron-resource
+- name: every-30-days
+  type: time
   source:
-    expression: "0 6 22 * *"
-    location: "America/New_York"
-    fire_immediately: true
+    interval: 30d
 
 resource_types:
 - name: slack-notification
   type: registry-image
   source:
     repository: cfcommunity/slack-notification-resource
-
-- name: cron-resource
-  type: docker-image
-  source:
-    repository: cftoolsmiths/cron-resource

--- a/container/pipeline-external-repository.yml
+++ b/container/pipeline-external-repository.yml
@@ -48,6 +48,51 @@ jobs:
       username: ((slack-username))
       icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 
+- name: continuous-scan
+  plan:
+    - in_parallel:
+      - get: src
+        trigger: false
+
+      - get: image
+        trigger: false
+        params:
+          format: oci
+
+      - get: common-pipelines
+        trigger: false
+
+      - get: monthly
+        trigger: true
+
+    - in_parallel:
+      - do:
+        - task: scan-image
+          file: common-pipelines/container/scan-image.yml
+
+        - task: cve-check
+          file: common-pipelines/container/cve-check.yml
+
+  on_failure:
+    put: slack
+    params:
+      text:  |
+        :x: Continuous Scan of `$BUILD_PIPELINE_NAME` FAILED
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: '#cg-platform-news'
+      username: ((slack-username))
+      icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
+
+  on_success:
+    put: slack
+    params:
+      text:  |
+        :white_check_mark: Continuous Scan of `$BUILD_PIPELINE_NAME` ran SUCCESSFULLY
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: '#cg-platform-news'
+      username: ((slack-username))
+      icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
+
 
 resources:
 
@@ -88,8 +133,20 @@ resources:
     branch: ((src-target-branch))
     # Since src is a repo outside the cloud-gov org, don't verify commits.
 
+- name: monthly
+  type: cron-resource
+  source:
+    expression: "0 6 22 * *"
+    location: "America/New_York"
+    fire_immediately: true
+
 resource_types:
 - name: slack-notification
   type: registry-image
   source:
     repository: cfcommunity/slack-notification-resource
+
+- name: cron-resource
+  type: docker-image
+  source:
+    repository: cftoolsmiths/cron-resource

--- a/container/pipeline.yml
+++ b/container/pipeline.yml
@@ -190,7 +190,7 @@ resources:
 - name: every-30-days
   type: time
   source:
-    interval: 30d
+    interval: 720h
 
 resource_types:
 - name: slack-notification

--- a/container/pipeline.yml
+++ b/container/pipeline.yml
@@ -108,7 +108,7 @@ jobs:
       - get: common-pipelines
         trigger: false
 
-      - get: monthly
+      - get: every-30-days
         trigger: true
 
     - in_parallel:
@@ -187,12 +187,10 @@ resources:
     branch: main
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
-- name: monthly
-  type: cron-resource
+- name: every-30-days
+  type: time
   source:
-    expression: "0 6 22 * *"
-    location: "America/New_York"
-    fire_immediately: true
+    interval: 30d
 
 resource_types:
 - name: slack-notification
@@ -204,8 +202,3 @@ resource_types:
   type: registry-image
   source:
     repository: teliaoss/github-pr-resource
-
-- name: cron-resource
-  type: docker-image
-  source:
-    repository: cftoolsmiths/cron-resource

--- a/container/pipeline.yml
+++ b/container/pipeline.yml
@@ -97,9 +97,6 @@ jobs:
 - name: continuous-scan
   plan:
     - in_parallel:
-      - get: src
-        trigger: false
-
       - get: image
         trigger: false
         params:
@@ -108,7 +105,7 @@ jobs:
       - get: common-pipelines
         trigger: false
 
-      - get: every-30-days
+      - get: daily
         trigger: true
 
     - in_parallel:
@@ -187,10 +184,10 @@ resources:
     branch: main
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
-- name: every-30-days
+- name: daily
   type: time
   source:
-    interval: 720h
+    interval: 24h
 
 resource_types:
 - name: slack-notification

--- a/container/pipeline.yml
+++ b/container/pipeline.yml
@@ -94,6 +94,50 @@ jobs:
       username: ((slack-username))
       icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 
+- name: continuous-scan
+  plan:
+    - in_parallel:
+      - get: src
+        trigger: false
+
+      - get: image
+        trigger: false
+        params:
+          format: oci
+
+      - get: common-pipelines
+        trigger: false
+
+      - get: monthly
+        trigger: true
+
+    - in_parallel:
+      - do:
+        - task: scan-image
+          file: common-pipelines/container/scan-image.yml
+
+        - task: cve-check
+          file: common-pipelines/container/cve-check.yml
+
+  on_failure:
+    put: slack
+    params:
+      text:  |
+        :x: Continuous Scan of `$BUILD_PIPELINE_NAME` FAILED
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: '#cg-platform-news'
+      username: ((slack-username))
+      icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
+
+  on_success:
+    put: slack
+    params:
+      text:  |
+        :white_check_mark: Continuous Scan of `$BUILD_PIPELINE_NAME` ran SUCCESSFULLY
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: '#cg-platform-news'
+      username: ((slack-username))
+      icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 
 resources:
 
@@ -143,6 +187,13 @@ resources:
     branch: main
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
+- name: monthly
+  type: cron-resource
+  source:
+    expression: "0 6 22 * *"
+    location: "America/New_York"
+    fire_immediately: true
+
 resource_types:
 - name: slack-notification
   type: registry-image
@@ -153,3 +204,8 @@ resource_types:
   type: registry-image
   source:
     repository: teliaoss/github-pr-resource
+
+- name: cron-resource
+  type: docker-image
+  source:
+    repository: cftoolsmiths/cron-resource


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds a continuous scan that runs once daily
- Posts notification to slack on success and fail so we can track for auditing purposes (keep record in slack in case pipeline gets deleted)

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

This continuous scan meets our requirements of scanning our containers at least once every 30 days
