### PR TITLE
Adds ARG line to dockerfile after base image has been called

### DIFF
--- a/container/oci-build.yml
+++ b/container/oci-build.yml
@@ -17,7 +17,12 @@ outputs:
 - name: image
 
 run:
-  path: build
+  path: sh
+  args:
+  - -exc
+  - |
+    sed -i '/FROM ${base_image}/a ARG DEBIAN_FRONTEND=noninteractive\n' src/Dockerfile
+    build
 
 params:
   # Full reference: https://github.com/concourse/oci-build-task#params

--- a/container/oci-build.yml
+++ b/container/oci-build.yml
@@ -21,7 +21,10 @@ run:
   args:
   - -exc
   - |
-    sed -i '/FROM ${base_image}/a ARG DEBIAN_FRONTEND=noninteractive\n' src/Dockerfile
+    if [[ -z "$DOCKERFILE"]]; then
+    export DOCKERFILE=$CONTEXT/Dockerfile
+    fi
+    sed -i '/FROM ${base_image} AS resource/a ARG DEBIAN_FRONTEND=noninteractive\n' $DOCKERFILE
     build
 
 params:


### PR DESCRIPTION
## Changes proposed in this pull request:

- This adds the `ARG DEBIAN_FRONTEND=noninteractive` line to any dockerfile, allowing the build to continue rather than waiting for user input

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Setting 'DEBIAN_FRONTEND' as an ARG in each dockerfile is better than setting it as an ENV in our base image, as the ARG only applies to the build, and won't cause any trouble when running the image in interactive mode later.
