### PR TITLE
Update grype ignore list

### DIFF
--- a/container/grype.yaml
+++ b/container/grype.yaml
@@ -5,3 +5,4 @@ ignore:
   - vulnerability: CVE-2007-4644   #false positive, alerting on package of same name
   - vulnerability: CVE-2018-20225  #disputed as intended functionality
   - vulnerability: CVE-2018-9057   #false positive as outlined here: https://github.com/anchore/grype/issues/1377
+  - vulnerability: CVE-2022-29217  #current jwt package contains the patch that fixes this: https://ubuntu.com/security/CVE-2022-29217


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updates the grype ignore list with the CVE for the JWT package that is a false positive. It is alerting on version number, but Ubuntu uses a different version number for their patch.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

This CVE is already patched on our system, so listing it here should cause no issues.
