### PR TITLE
add github advisory number

### DIFF
--- a/container/grype.yaml
+++ b/container/grype.yaml
@@ -1,8 +1,9 @@
 #Grype ignore configurations.
 
 ignore:
-  - vulnerability: CVE-2007-4642   #false positive, alerting on package of same name
-  - vulnerability: CVE-2007-4644   #false positive, alerting on package of same name
-  - vulnerability: CVE-2018-20225  #disputed as intended functionality
-  - vulnerability: CVE-2018-9057   #false positive as outlined here: https://github.com/anchore/grype/issues/1377
-  - vulnerability: CVE-2022-29217  #current jwt package contains the patch that fixes this: https://ubuntu.com/security/CVE-2022-29217
+  - vulnerability: CVE-2007-4642        #false positive, alerting on package of same name
+  - vulnerability: CVE-2007-4644        #false positive, alerting on package of same name
+  - vulnerability: CVE-2018-20225       #disputed as intended functionality
+  - vulnerability: CVE-2018-9057        #false positive as outlined here: https://github.com/anchore/grype/issues/1377
+  - vulnerability: CVE-2022-29217       #current jwt package contains the patch that fixes this: https://ubuntu.com/security/CVE-2022-29217
+  - vulnerability: GHSA-ffqj-6fqr-9h24  #current jwt package contains the patch that fixes this: https://ubuntu.com/security/CVE-2022-29217


### PR DESCRIPTION
## Changes proposed in this pull request:

- CVE-2022-29217 also has a Github advisory that the scan is alerting on, so it needs to be added to the exception list

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, this refers to the same CVE-2022-29217 already added to the list
