### PR TITLE
add common-pipelines as input

### DIFF
--- a/container/oci-build.yml
+++ b/container/oci-build.yml
@@ -12,6 +12,7 @@ caches:
 inputs:
 - name: src
 - name: base-image
+- name: common-pipelines
 
 outputs:
 - name: image


### PR DESCRIPTION
## Changes proposed in this pull request:

- See title

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just adds common-pipelines as input to the oci-build task so the Dockerfile can be found
