### PR TITLE
Update CVE check handling

### DIFF
--- a/container/cve-check.sh
+++ b/container/cve-check.sh
@@ -85,6 +85,7 @@ done
 
 if [ ${#past_due_critical_cves[@]} -ge 1 ] || [ ${#past_due_high_cves[@]} -ge 1 ]
 then echo ":warning: Past Due CVEs need to be reviewed for image ${IMAGENAME}." > message/alert.txt
+exit 0
 fi
 
 if [ ${#current_critical_cves[@]} -ge 1 ] || [ ${#current_high_cves[@]} -ge 1 ]

--- a/container/cve-check.sh
+++ b/container/cve-check.sh
@@ -84,7 +84,7 @@ for failed_issue in ${failed_cves[@]}; do
 done
 
 if [ ${#past_due_critical_cves[@]} -ge 1 ] || [ ${#past_due_high_cves[@]} -ge 1 ]
-then exit 1
+then echo ":warning: Past Due CVEs need to be reviewed for image ${IMAGENAME}." > message/alert.txt
 fi
 
 if [ ${#current_critical_cves[@]} -ge 1 ] || [ ${#current_high_cves[@]} -ge 1 ]


### PR DESCRIPTION
## Changes proposed in this pull request:

- Modifies the CVE check to no longer fail on past due CVEs
- Sends a notification to slack that these CVEs exist and should be looked at (may not be necessary when we get the tracking system in place, but adding this notification for now so we can have a record)

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

We will be using another method to track CVEs, and changing this will unblock other container hardening work
