### PR TITLE
Switch back to specifying image in task file

### DIFF
--- a/container/cve-check.yml
+++ b/container/cve-check.yml
@@ -1,6 +1,7 @@
 ---
 platform: linux
 
+#cannot be factored out because it intereferes with oci-build-task output
 image_resource:
   type: registry-image
   source:

--- a/container/cve-check.yml
+++ b/container/cve-check.yml
@@ -1,6 +1,15 @@
 ---
 platform: linux
 
+image_resource:
+  type: registry-image
+  source:
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: general-task
+    aws_region: us-gov-west-1
+    tag: latest
+
 inputs:
 - name: common-pipelines
 - name: cves

--- a/container/pipeline-external-repository.yml
+++ b/container/pipeline-external-repository.yml
@@ -28,11 +28,9 @@ jobs:
       - do:
         - task: scan-image
           file: common-pipelines/container/scan-image.yml
-          image: general-task
 
         - task: cve-check
           file: common-pipelines/container/cve-check.yml
-          image: general-task
 
     - put: image
       inputs:
@@ -72,11 +70,9 @@ jobs:
       - do:
         - task: scan-image
           file: common-pipelines/container/scan-image.yml
-          image: general-task
 
         - task: cve-check
           file: common-pipelines/container/cve-check.yml
-          image: general-task
 
   on_failure:
     put: slack

--- a/container/pipeline.yml
+++ b/container/pipeline.yml
@@ -37,12 +37,10 @@ jobs:
       - do:
         - task: scan-image
           file: common-pipelines/container/scan-image.yml
-          image: general-task
 
         - task: cve-check
           file: common-pipelines/container/cve-check.yml
-          image: general-task
-
+  
   on_failure:
     put: pull-request
     params:
@@ -78,11 +76,9 @@ jobs:
       - do:
         - task: scan-image
           file: common-pipelines/container/scan-image.yml
-          image: general-task
 
         - task: cve-check
           file: common-pipelines/container/cve-check.yml
-          image: general-task
 
     - put: image
       inputs:
@@ -122,11 +118,9 @@ jobs:
       - do:
         - task: scan-image
           file: common-pipelines/container/scan-image.yml
-          image: general-task
 
         - task: cve-check
           file: common-pipelines/container/cve-check.yml
-          image: general-task
 
   on_failure:
     put: slack

--- a/container/scan-image.yml
+++ b/container/scan-image.yml
@@ -1,6 +1,7 @@
 ---
 platform: linux
 
+#cannot be factored out because it intereferes with oci-build-task output
 image_resource:
   type: registry-image
   source:

--- a/container/scan-image.yml
+++ b/container/scan-image.yml
@@ -1,6 +1,15 @@
 ---
 platform: linux
 
+image_resource:
+  type: registry-image
+  source:
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: general-task
+    aws_region: us-gov-west-1
+    tag: latest
+
 inputs:
 - name: common-pipelines
 - name: image


### PR DESCRIPTION
## Changes proposed in this pull request:

- Using `image` when calling the scan task interferes with the image output by the oci-build, so this goes back to specifying the image in the task files themselves

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixes a pipeline issue