### PR TITLE
Install grype to run cve scans

### DIFF
--- a/container/scan-image.sh
+++ b/container/scan-image.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+echo "Installing grype cli"
+curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
+
 grype image/image.tar -c common-pipelines/container/grype.yaml -q -o json --file cves/output.json
 grype image/image.tar -c common-pipelines/container/grype.yaml -q -o table --file table.txt
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- This installs grype before we try to run the cve scans
- Necessary now that we are using the general-task image

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Need to install grype just to run the cve scans. Doesn't need to persist on the image.
