### PR TITLE
Add dockerfile for github-pr-resource

### DIFF
--- a/container/dockerfiles/github-pr-resource/Dockerfile
+++ b/container/dockerfiles/github-pr-resource/Dockerfile
@@ -1,0 +1,23 @@
+ARG base_image
+
+FROM golang:1.14 as builder
+ADD . /go/src/github.com/telia-oss/github-pr-resource
+WORKDIR /go/src/github.com/telia-oss/github-pr-resource
+RUN curl -sL https://taskfile.dev/install.sh | sh
+RUN ./bin/task build
+
+FROM ${base_image} AS resource
+COPY --from=builder /go/src/github.com/telia-oss/github-pr-resource/build /opt/resource
+RUN apt update && apt upgrade -y -o Dpkg::Options::="--force-confdef"
+RUN apt install -y --no-install-recommends \
+    git \
+    git-lfs \
+    openssh-server \
+    openssh-client \
+    && chmod +x /opt/resource/*
+COPY scripts/askpass.sh /usr/local/bin/askpass.sh
+ADD scripts/install_git_crypt.sh install_git_crypt.sh
+RUN ./install_git_crypt.sh && rm ./install_git_crypt.sh
+
+FROM resource
+LABEL MAINTAINER=telia-oss


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds dockerfile with modifications so that we can harden the external github-pr-resource

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Adding another resource to harden and scan
