### PR TITLE
Install git-crypt from package manager

### DIFF
--- a/container/dockerfiles/github-pr-resource/Dockerfile
+++ b/container/dockerfiles/github-pr-resource/Dockerfile
@@ -14,10 +14,9 @@ RUN apt install -y --no-install-recommends \
     git-lfs \
     openssh-server \
     openssh-client \
+    git-crypt \
     && chmod +x /opt/resource/*
 COPY scripts/askpass.sh /usr/local/bin/askpass.sh
-ADD scripts/install_git_crypt.sh install_git_crypt.sh
-RUN ./install_git_crypt.sh && rm ./install_git_crypt.sh
 
 FROM resource
 LABEL MAINTAINER=telia-oss


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updates dockerfile to install git-crypt using apt rather than the repo install script

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, this just fixes an issue with building the image
