### PR TITLE
Streamline pipelines

### DIFF
--- a/container/README.md
+++ b/container/README.md
@@ -49,7 +49,7 @@ Some vars in `your-repo/ci/vars/yml` may also be assigned empty lists:
 docker-file-path: []
 ```
 
-Most often you will set the `docker-file-path` to an empty list, unless you've created a Dockerfile for an external resource in this repo. In this case you will also want to set the `docker-file-trigger` to `true` so the pipeline triggers on any Dockerfile changes.
+Most often you will set the `docker-file-path` to an empty list, unless you've created a Dockerfile for an external resource in this repo. If you do add a value to this list, you will most likely also want to set the `docker-file-trigger` to `true` so the pipeline triggers on any Dockerfile changes.
 
 Many params have reasonable defaults and don't need to be explicitly set. Test with your repository to find out.
 

--- a/container/README.md
+++ b/container/README.md
@@ -46,10 +46,10 @@ Some vars in `your-repo/ci/vars/yml` may also be assigned empty lists:
 
 ```yaml
 #vars.yml
-docker-file-path: []
+dockerfile-path: []
 ```
 
-Most often you will set the `docker-file-path` to an empty list, unless you've created a Dockerfile for an external resource in this repo. If you do add a value to this list, you will most likely also want to set the `docker-file-trigger` to `true` so the pipeline triggers on any Dockerfile changes.
+Most often you will set the `dockerfile-path` to an empty list, unless you've created a Dockerfile for an external resource in this repo. If you do add a value to this list, you will most likely also want to set the `dockerfile-trigger` to `true` so the pipeline triggers on any Dockerfile changes.
 
 Many params have reasonable defaults and don't need to be explicitly set. Test with your repository to find out.
 

--- a/container/README.md
+++ b/container/README.md
@@ -42,6 +42,15 @@ oci-build-params:
   DOCKERFILE: build/docker/Dockerfile # specify Dockerfile location when it is not in the repository root
 ```
 
+Some vars in `your-repo/ci/vars/yml` may also be assigned empty lists:
+
+```yaml
+#vars.yml
+docker-file-path: []
+```
+
+Most often you will set the `docker-file-path` to an empty list, unless you've created a Dockerfile for an external resource in this repo. In this case you will also want to set the `docker-file-trigger` to `true` so the pipeline triggers on any Dockerfile changes.
+
 Many params have reasonable defaults and don't need to be explicitly set. Test with your repository to find out.
 
 Note that `vars.yml` cannot be empty; it must include maps, even empty ones, for every parameter specified in the pipeline, or the `set-self` job will fail because it cannot find the vars.

--- a/container/examples/cloud-gov-repo/ci/vars.yml
+++ b/container/examples/cloud-gov-repo/ci/vars.yml
@@ -5,5 +5,5 @@ image-repository: cloud-gov-repo
 oci-build-params: {}
 src-repo: cloud-gov/ubuntu-hardened
 common-pipelines-trigger: false
-docker-file-path: []
-docker-file-trigger: false
+dockerfile-path: []
+dockerfile-trigger: false

--- a/container/examples/cloud-gov-repo/ci/vars.yml
+++ b/container/examples/cloud-gov-repo/ci/vars.yml
@@ -4,3 +4,6 @@ base-image-tag: "22.04"
 image-repository: cloud-gov-repo
 oci-build-params: {}
 src-repo: cloud-gov/ubuntu-hardened
+common-pipelines-trigger: false
+docker-file-path: []
+docker-file-trigger: false

--- a/container/examples/external-repo/ci/vars.yml
+++ b/container/examples/external-repo/ci/vars.yml
@@ -4,3 +4,6 @@ image-repository: external-repo
 oci-build-params: {}
 src-repo: external-org/external-repo
 src-target-branch: main
+common-pipelines-trigger: false
+docker-file-path: []
+docker-file-trigger: false

--- a/container/examples/external-repo/ci/vars.yml
+++ b/container/examples/external-repo/ci/vars.yml
@@ -5,5 +5,5 @@ oci-build-params: {}
 src-repo: external-org/external-repo
 src-target-branch: main
 common-pipelines-trigger: false
-docker-file-path: []
-docker-file-trigger: false
+dockerfile-path: []
+dockerfile-trigger: false

--- a/container/oci-build.yml
+++ b/container/oci-build.yml
@@ -13,6 +13,7 @@ inputs:
 - name: src
 - name: base-image
 - name: common-pipelines
+- name: docker-file
 
 outputs:
 - name: image

--- a/container/oci-build.yml
+++ b/container/oci-build.yml
@@ -13,7 +13,7 @@ inputs:
 - name: src
 - name: base-image
 - name: common-pipelines
-- name: docker-file
+- name: dockerfile
 
 outputs:
 - name: image

--- a/container/oci-build.yml
+++ b/container/oci-build.yml
@@ -13,7 +13,7 @@ inputs:
 - name: src
 - name: base-image
 - name: common-pipelines
-- name: dockerfile
+- name: common-dockerfiles
 
 outputs:
 - name: image

--- a/container/pipeline-external-repository.yml
+++ b/container/pipeline-external-repository.yml
@@ -13,8 +13,8 @@ jobs:
       - get: common-pipelines
         trigger: ((common-pipelines-trigger))
 
-      - get: docker-file
-        trigger: ((docker-file-trigger))
+      - get: dockerfile
+        trigger: ((dockerfile-trigger))
 
       - get: general-task
 
@@ -118,13 +118,13 @@ resources:
     paths: ["container/*"]
     ignore_paths: ["container/dockerfiles/*"]
 
-- name: docker-file
+- name: dockerfile
   type: git
   source:
     uri: https://github.com/cloud-gov/common-pipelines
     branch: main
     commit_verification_keys: ((cloud-gov-pgp-keys))
-    paths: ((docker-file-path))
+    paths: ((dockerfile-path))
 
 - name: image
   type: registry-image

--- a/container/pipeline-external-repository.yml
+++ b/container/pipeline-external-repository.yml
@@ -13,7 +13,7 @@ jobs:
       - get: common-pipelines
         trigger: ((common-pipelines-trigger))
 
-      - get: dockerfile
+      - get: common-dockerfile
         trigger: ((dockerfile-trigger))
 
       - get: general-task
@@ -118,7 +118,7 @@ resources:
     paths: ["container/*"]
     ignore_paths: ["container/dockerfiles/*"]
 
-- name: dockerfile
+- name: common-dockerfiles
   type: git
   source:
     uri: https://github.com/cloud-gov/common-pipelines

--- a/container/pipeline-external-repository.yml
+++ b/container/pipeline-external-repository.yml
@@ -11,7 +11,10 @@ jobs:
           format: oci
 
       - get: common-pipelines
-        trigger: true
+        trigger: ((common-pipelines-trigger))
+
+      - get: docker-file
+        trigger: ((docker-file-trigger))
 
       - get: general-task
 
@@ -112,6 +115,16 @@ resources:
     uri: https://github.com/cloud-gov/common-pipelines
     branch: main
     commit_verification_keys: ((cloud-gov-pgp-keys))
+    paths: ["container/*"]
+    ignore_paths: ["container/dockerfiles/*"]
+
+- name: docker-file
+  type: git
+  source:
+    uri: https://github.com/cloud-gov/common-pipelines
+    branch: main
+    commit_verification_keys: ((cloud-gov-pgp-keys))
+    paths: ((docker-file-path))
 
 - name: image
   type: registry-image

--- a/container/pipeline.yml
+++ b/container/pipeline.yml
@@ -14,8 +14,8 @@ jobs:
       - get: common-pipelines
         trigger: ((common-pipelines-trigger))
 
-      - get: docker-file
-        trigger: ((docker-file-trigger))
+      - get: dockerfile
+        trigger: ((dockerfile-trigger))
 
       - get: general-task
 
@@ -64,8 +64,8 @@ jobs:
       - get: common-pipelines
         trigger: ((common-pipelines-trigger))
 
-      - get: docker-file
-        trigger: ((docker-file-trigger))
+      - get: dockerfile
+        trigger: ((dockerfile-trigger))
 
       - get: general-task
 
@@ -168,13 +168,13 @@ resources:
     paths: ["container/*"]
     ignore_paths: ["container/dockerfiles/*"]
 
-- name: docker-file
+- name: dockerfile
   type: git
   source:
     uri: https://github.com/cloud-gov/common-pipelines
     branch: main
     commit_verification_keys: ((cloud-gov-pgp-keys))
-    paths: ((docker-file-path))
+    paths: ((dockerfile-path))
 
 - name: image
   type: registry-image

--- a/container/pipeline.yml
+++ b/container/pipeline.yml
@@ -14,7 +14,7 @@ jobs:
       - get: common-pipelines
         trigger: ((common-pipelines-trigger))
 
-      - get: dockerfile
+      - get: common-dockerfiles
         trigger: ((dockerfile-trigger))
 
       - get: general-task
@@ -64,7 +64,7 @@ jobs:
       - get: common-pipelines
         trigger: ((common-pipelines-trigger))
 
-      - get: dockerfile
+      - get: common-dockerfiles
         trigger: ((dockerfile-trigger))
 
       - get: general-task
@@ -168,7 +168,7 @@ resources:
     paths: ["container/*"]
     ignore_paths: ["container/dockerfiles/*"]
 
-- name: dockerfile
+- name: common-dockerfiles
   type: git
   source:
     uri: https://github.com/cloud-gov/common-pipelines

--- a/container/pipeline.yml
+++ b/container/pipeline.yml
@@ -12,7 +12,7 @@ jobs:
           format: oci
 
       - get: common-pipelines
-        trigger: true
+        trigger: ((common-pipelines-trigger))
 
       - get: general-task
 
@@ -59,7 +59,7 @@ jobs:
           format: oci
 
       - get: common-pipelines
-        trigger: true
+        trigger: ((common-pipelines-trigger))
 
       - get: general-task
 
@@ -159,6 +159,8 @@ resources:
     uri: https://github.com/cloud-gov/common-pipelines
     branch: main
     commit_verification_keys: ((cloud-gov-pgp-keys))
+    paths: ["container/*"]
+    ignore_paths: ["container/dockerfiles/*"]
 
 - name: image
   type: registry-image

--- a/container/pipeline.yml
+++ b/container/pipeline.yml
@@ -64,6 +64,9 @@ jobs:
       - get: common-pipelines
         trigger: ((common-pipelines-trigger))
 
+      - get: docker-file
+        trigger: ((docker-file-trigger))
+
       - get: general-task
 
     - task: oci-build

--- a/container/pipeline.yml
+++ b/container/pipeline.yml
@@ -14,6 +14,9 @@ jobs:
       - get: common-pipelines
         trigger: ((common-pipelines-trigger))
 
+      - get: docker-file
+        trigger: ((docker-file-trigger))
+
       - get: general-task
 
     - put: pull-request
@@ -161,6 +164,14 @@ resources:
     commit_verification_keys: ((cloud-gov-pgp-keys))
     paths: ["container/*"]
     ignore_paths: ["container/dockerfiles/*"]
+
+- name: docker-file
+  type: git
+  source:
+    uri: https://github.com/cloud-gov/common-pipelines
+    branch: main
+    commit_verification_keys: ((cloud-gov-pgp-keys))
+    paths: ((docker-file-path))
 
 - name: image
   type: registry-image


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updates common-pipelines resource to only update when there is a change to the container directory, and to ignore any changes to the dockerfile directory
- Adds a docker-file resource that pipelines can use to trigger on a Dockerfile change
- Parameterize common-pipelines trigger value so that we can set on each pipeline whether we want it to trigger on updates. This should allow us to keep pipelines from triggering once for common-pipeline changes, and then again when the ubuntu-hardened image is created.
- Updates README

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, this is simply to improve our pipeline performance and to keep image build from running twice.
