### PR TITLE
remove unneeded certificate line

### DIFF
--- a/container/dockerfiles/email-resource/Dockerfile
+++ b/container/dockerfiles/email-resource/Dockerfile
@@ -6,8 +6,6 @@ WORKDIR /usr/src/app
 
 COPY . .
 
-ADD https://curl.haxx.se/ca/cacert.pem /etc/ssl/certs/ca-certificates.crt
-
 RUN export GOPATH=$PWD/go && export PATH=$GOPATH/bin:$PATH
 
 RUN go mod download && \


### PR DESCRIPTION
## Changes proposed in this pull request:

- After further research into the code this cert doesn't appear to be used

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Removing certificate line as it doesn't appear to be necessary
