### PR TITLE
Update pull-request resource type

### DIFF
--- a/container/pipeline.yml
+++ b/container/pipeline.yml
@@ -242,4 +242,8 @@ resource_types:
 - name: pull-request
   type: registry-image
   source:
-    repository: teliaoss/github-pr-resource
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: github-pr-resource
+    aws_region: us-gov-west-1
+    tag: latest


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updates pull-request resource type to use our hardened github-pr-resource

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Updates another resource to use our hardened image
