### PR TITLE
Trigger jobs only after set-self has run to ensure current src is used

### DIFF
--- a/ci/container/pipeline.yml
+++ b/ci/container/pipeline.yml
@@ -12,6 +12,7 @@ jobs:
   plan:
     - get: src
       trigger: true
+      passed: [set-self]
     - across:
       - var: name # repo, pipeline, and image name; all the same.
         values:
@@ -31,6 +32,7 @@ jobs:
   plan:
     - get: src
       trigger: true
+      passed: [set-self]
     - across:
       - var: name # repo, pipeline, and image name; all the same.
         values:


### PR DESCRIPTION
## Changes proposed in this pull request:

- See title. Without this, updates to src can trigger a run of the internal and external jobs before the pipeline has re-set itself.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.