### PR TITLE
remove software inventory task from continuous scan

### DIFF
--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -81,10 +81,6 @@ jobs:
         - task: cve-check
           file: common-pipelines/container/cve-check.yml
         
-        - task: software-inventory
-          file: common-pipelines/container/software-inventory.yml
-          image: image
-
   on_failure:
     put: slack
     params:

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -136,10 +136,6 @@ jobs:
         - task: cve-check
           file: common-pipelines/container/cve-check.yml
 
-        - task: software-inventory
-          file: common-pipelines/container/software-inventory.yml
-          image: image
-
   on_failure:
     put: slack
     params:


### PR DESCRIPTION
## Changes proposed in this pull request:

- Removes the software inventory task from the continuous scan so that job doesn't error out

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just removing a task that causes an error
