### PR TITLE
change slack channel

### DIFF
--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -53,7 +53,7 @@ jobs:
       text:  |
         :x: Pipeline `$BUILD_PIPELINE_NAME` FAILED to upload image to ECR
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform-news'
+      channel: '#cg-platform'
       username: ((slack-username))
       icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 

--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -53,7 +53,7 @@ jobs:
       text:  |
         :x: Pipeline `$BUILD_PIPELINE_NAME` FAILED to upload image to ECR
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform'
+      channel: ((slack-channel-failure))
       username: ((slack-username))
       icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -108,7 +108,7 @@ jobs:
       text:  |
         :x: Pipeline `$BUILD_PIPELINE_NAME` FAILED to upload image to ECR
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform-news'
+      channel: '#cg-platform'
       username: ((slack-username))
       icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -108,7 +108,7 @@ jobs:
       text:  |
         :x: Pipeline `$BUILD_PIPELINE_NAME` FAILED to upload image to ECR
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform'
+      channel: ((slack-channel-failure))
       username: ((slack-username))
       icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Sends notification to cg-platform channel when image build fails

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Sending the notification to this channel will increase the likelihood that we notice the issue and fix it
