### PR TITLE
moved cf-resource to internal and updated src-repo

### DIFF
--- a/ci/container/internal/cf-resource/vars.yml
+++ b/ci/container/internal/cf-resource/vars.yml
@@ -4,7 +4,7 @@ image-repository: cf-resource
 oci-build-params: {
   DOCKERFILE: src/dockerfiles/ubuntu/Dockerfile
 }
-src-repo: cloudfoundry-community/cf-resource
+src-repo: cloud-gov/cf-resource
 src-target-branch: master
 common-pipelines-trigger: false
 dockerfile-path: []

--- a/ci/container/pipeline.yml
+++ b/ci/container/pipeline.yml
@@ -23,6 +23,7 @@ jobs:
           - slack-notification-resource
           - s3-resource
           - github-pr-resource
+          - cf-resource
       do:
       - set_pipeline: ((.:name))
         file: src/container/pipeline-internal.yml
@@ -38,7 +39,6 @@ jobs:
       - var: name # repo, pipeline, and image name; all the same.
         values:
           - cf-cli-resource
-          - cf-resource
           - email-resource
           - git-resource
           - registry-image-resource


### PR DESCRIPTION
## Changes proposed in this pull request:

- Moved cf-resource to internal
- Updated source to point to new cloud-gov location
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the output, which can prevent unintentional leaks of sensitive data.

## Security considerations

This should improve security by moving cloud-gov to our internal fork using hardened pipelines and utilizing more of our internal checks in the process.
