### PR TITLE
Add script to import scan to defect dojo

### DIFF
--- a/container/import-scan.sh
+++ b/container/import-scan.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Send POST request containing grype results to Defect Dojo
+
+curl -X 'POST' $DEFECTDOJO_IMPORT_URL \
+  -H 'accept: application/json' \
+  -H 'Content-Type: multipart/form-data' \
+  -H 'Authorization: Token $DEFECTDOJO_AUTH_TOKEN' \
+  -F 'product_type_name=Container Image' \
+  -F 'active=true' \
+  -F 'minimum_severity=Info' \
+  -F 'verified=true' \
+  -F 'scan_type=Anchore Grype' \
+  -F 'product_name=${IMAGENAME}' \
+  -F 'engagement_name=$SCAN_TYPE' \
+  -F 'auto_create_context=true' \
+  -F 'file=@cves/output.json;type=application/json'

--- a/container/import-scan.sh
+++ b/container/import-scan.sh
@@ -12,6 +12,6 @@ curl -X "POST" $DEFECTDOJO_IMPORT_URL \
   -F "verified=true" \
   -F "scan_type=Anchore Grype" \
   -F "product_name=${IMAGENAME}" \
-  -F "engagement_name=$SCAN_TYPE" \
+  -F "engagement_name=$SCANTYPE" \
   -F "auto_create_context=true" \
   -F "file=@cves/output.json;type=application/json"

--- a/container/import-scan.sh
+++ b/container/import-scan.sh
@@ -12,7 +12,7 @@ curl -X "POST" $DEFECTDOJO_IMPORT_URL \
   -F "verified=true" \
   -F "scan_type=Anchore Grype" \
   -F "product_name=$IMAGENAME" \
-  -F "engagement_name=$SCANTYPE" \
+  -F "engagement_name=CVE Scan" \
   -F "auto_create_context=true" \
   -F "deduplication_on_engagement=true" \
   -F "file=@cves/output.json;type=application/json"

--- a/container/import-scan.sh
+++ b/container/import-scan.sh
@@ -11,7 +11,8 @@ curl -X "POST" $DEFECTDOJO_IMPORT_URL \
   -F "minimum_severity=Info" \
   -F "verified=true" \
   -F "scan_type=Anchore Grype" \
-  -F "product_name=${IMAGENAME}" \
+  -F "product_name=$IMAGENAME" \
   -F "engagement_name=$SCANTYPE" \
   -F "auto_create_context=true" \
+  -F "deduplication_on_engagement=true" \
   -F "file=@cves/output.json;type=application/json"

--- a/container/import-scan.sh
+++ b/container/import-scan.sh
@@ -11,7 +11,7 @@ curl -X "POST" $DEFECTDOJO_IMPORT_URL \
   -F "minimum_severity=Info" \
   -F "verified=true" \
   -F "scan_type=Anchore Grype" \
-  -F "product_name=$IMAGENAME" \
+  -F "product_name=${IMAGENAME}" \
   -F "engagement_name=$SCAN_TYPE" \
   -F "auto_create_context=true" \
   -F "file=@cves/output.json;type=application/json"

--- a/container/import-scan.sh
+++ b/container/import-scan.sh
@@ -14,5 +14,4 @@ curl -X "POST" $DEFECTDOJO_IMPORT_URL \
   -F "product_name=$IMAGENAME" \
   -F "engagement_name=CVE Scan" \
   -F "auto_create_context=true" \
-  -F "deduplication_on_engagement=true" \
   -F "file=@cves/output.json;type=application/json"

--- a/container/import-scan.sh
+++ b/container/import-scan.sh
@@ -2,16 +2,16 @@
 
 # Send POST request containing grype results to Defect Dojo
 
-curl -X 'POST' $DEFECTDOJO_IMPORT_URL \
-  -H 'accept: application/json' \
-  -H 'Content-Type: multipart/form-data' \
-  -H 'Authorization: Token $DEFECTDOJO_AUTH_TOKEN' \
-  -F 'product_type_name=Container Image' \
-  -F 'active=true' \
-  -F 'minimum_severity=Info' \
-  -F 'verified=true' \
-  -F 'scan_type=Anchore Grype' \
-  -F 'product_name=${IMAGENAME}' \
-  -F 'engagement_name=$SCAN_TYPE' \
-  -F 'auto_create_context=true' \
-  -F 'file=@cves/output.json;type=application/json'
+curl -X "POST" $DEFECTDOJO_IMPORT_URL \
+  -H "accept: application/json" \
+  -H "Content-Type: multipart/form-data" \
+  -H "Authorization: Token $DEFECTDOJO_AUTH_TOKEN" \
+  -F "product_type_name=Container Image" \
+  -F "active=true" \
+  -F "minimum_severity=Info" \
+  -F "verified=true" \
+  -F "scan_type=Anchore Grype" \
+  -F "product_name=$IMAGENAME" \
+  -F "engagement_name=$SCAN_TYPE" \
+  -F "auto_create_context=true" \
+  -F "file=@cves/output.json;type=application/json"

--- a/container/import-scan.yml
+++ b/container/import-scan.yml
@@ -18,6 +18,5 @@ run:
   path: common-pipelines/container/import-scan.sh
 
 params:
-  SCAN_TYPE:
   DEFECTDOJO_IMPORT_URL: ((defectdojo_import_url))
   DEFECTDOJO_AUTH_TOKEN: ((defectdojo_auth_token))

--- a/container/import-scan.yml
+++ b/container/import-scan.yml
@@ -1,0 +1,23 @@
+---
+platform: linux
+
+#cannot be factored out because it intereferes with oci-build-task output
+image_resource:
+  type: registry-image
+  source:
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: general-task
+    aws_region: us-gov-west-1
+    tag: latest
+
+inputs:
+- name: cves
+
+run:
+  path: common-pipelines/container/import-scan.sh
+
+params:
+  SCAN_TYPE:
+  DEFECTDOJO_IMPORT_URL: ((defectdojo_import_url))
+  DEFECTDOJO_AUTH_TOKEN: ((defectdojo_auth_token))

--- a/container/import-scan.yml
+++ b/container/import-scan.yml
@@ -12,6 +12,7 @@ image_resource:
     tag: latest
 
 inputs:
+- name: common-pipelines
 - name: cves
 
 run:

--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -35,6 +35,11 @@ jobs:
         - task: cve-check
           file: common-pipelines/container/cve-check.yml
 
+        - task: import-scan
+          file: common-pipelines/container/import-scan.yml
+          params:
+            IMAGENAME: ((image-repository))
+
         - task: software-inventory
           file: common-pipelines/container/software-inventory.yml
           image: image
@@ -80,6 +85,11 @@ jobs:
 
         - task: cve-check
           file: common-pipelines/container/cve-check.yml
+
+        - task: import-scan
+          file: common-pipelines/container/import-scan.yml
+          params:
+            IMAGENAME: ((image-repository))
         
   on_failure:
     put: slack

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -93,7 +93,8 @@ jobs:
         - task: import-scan
           file: common-pipelines/container/import-scan.yml
           params:
-            SCAN_TYPE: "Main"
+            SCANTYPE: "Main"
+            IMAGENAME: ((image-repository))
 
         - task: software-inventory
           file: common-pipelines/container/software-inventory.yml

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -93,7 +93,6 @@ jobs:
         - task: import-scan
           file: common-pipelines/container/import-scan.yml
           params:
-            SCANTYPE: "Main"
             IMAGENAME: ((image-repository))
 
         - task: software-inventory

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -141,6 +141,11 @@ jobs:
         - task: cve-check
           file: common-pipelines/container/cve-check.yml
 
+        - task: import-scan
+          file: common-pipelines/container/import-scan.yml
+          params:
+            IMAGENAME: ((image-repository))
+
   on_failure:
     put: slack
     params:

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -90,6 +90,11 @@ jobs:
         - task: cve-check
           file: common-pipelines/container/cve-check.yml
 
+        - task: import-scan
+          file: common-pipelines/container/import-scan.ynl
+          params:
+            scan_type: "Main"
+
         - task: software-inventory
           file: common-pipelines/container/software-inventory.yml
           image: image

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -93,7 +93,7 @@ jobs:
         - task: import-scan
           file: common-pipelines/container/import-scan.yml
           params:
-            scan_type: "Main"
+            SCAN_TYPE: "Main"
 
         - task: software-inventory
           file: common-pipelines/container/software-inventory.yml

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -91,7 +91,7 @@ jobs:
           file: common-pipelines/container/cve-check.yml
 
         - task: import-scan
-          file: common-pipelines/container/import-scan.ynl
+          file: common-pipelines/container/import-scan.yml
           params:
             scan_type: "Main"
 

--- a/container/pipeline-pages.yml
+++ b/container/pipeline-pages.yml
@@ -87,6 +87,11 @@ jobs:
         - task: cve-check
           file: common-pipelines/container/cve-check.yml
 
+        - task: import-scan
+          file: common-pipelines/container/import-scan.yml
+          params:
+            IMAGENAME: ((image-repository))
+
         - task: software-inventory
           file: common-pipelines/container/software-inventory.yml
           image: image
@@ -132,6 +137,11 @@ jobs:
 
         - task: cve-check
           file: common-pipelines/container/cve-check.yml
+
+        - task: import-scan
+          file: common-pipelines/container/import-scan.yml
+          params:
+            IMAGENAME: ((image-repository))
         
   on_failure:
     put: slack


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds script to import grype scan into defect dojo

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Importing CVE scans of container images
