### PR TITLE
Update notification channel

### DIFF
--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -87,7 +87,7 @@ jobs:
       text:  |
         :x: Continuous Scan of `$BUILD_PIPELINE_NAME` FAILED
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform-news'
+      channel: ((slack-channel-failure))
       username: ((slack-username))
       icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -142,7 +142,7 @@ jobs:
       text:  |
         :x: Continuous Scan of `$BUILD_PIPELINE_NAME` FAILED
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform-news'
+      channel: ((slack-channel-failure))
       username: ((slack-username))
       icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 

--- a/container/pipeline-pages.yml
+++ b/container/pipeline-pages.yml
@@ -46,7 +46,7 @@ jobs:
       text:  |
         :x: Pipeline `$BUILD_PIPELINE_NAME` FAILED pull request tasks
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: ((slack-channel))
+      channel: ((slack-channel-failure))
       username: ((slack-username))
       icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 
@@ -139,7 +139,7 @@ jobs:
       text:  |
         :x: Continuous Scan of `$BUILD_PIPELINE_NAME` FAILED
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: ((slack-channel))
+      channel: ((slack-channel-failure))
       username: ((slack-username))
       icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updates failure notifications to send to a channel with more visibility

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Failures will be sent to the correct channel so we have more visibility
