### PR TITLE
Build hardened docker image for cloud-service-broker

### DIFF
--- a/ci/container/external/cloud-service-broker/vars.yml
+++ b/ci/container/external/cloud-service-broker/vars.yml
@@ -1,0 +1,8 @@
+base-image: ubuntu-hardened
+base-image-tag: "latest"
+image-repository: cloud-service-broker
+oci-build-params: {}
+src-repo: cloudfoundry/cloud-service-broker
+common-pipelines-trigger: false
+dockerfile-path: ["container/dockerfiles/cloud-service-broker/Dockerfile"]
+dockerfile-trigger: false

--- a/ci/container/pipeline.yml
+++ b/ci/container/pipeline.yml
@@ -40,6 +40,7 @@ jobs:
       - var: name # repo, pipeline, and image name; all the same.
         values:
           - cf-cli-resource
+          - cloud-service-broker
           - email-resource
           - git-resource
           - registry-image-resource

--- a/container/dockerfiles/cloud-service-broker/Dockerfile
+++ b/container/dockerfiles/cloud-service-broker/Dockerfile
@@ -1,0 +1,24 @@
+# Adapted from https://github.com/cloudfoundry/cloud-service-broker/blob/main/Dockerfile
+FROM golang:1.22 AS build
+WORKDIR /app
+ADD . /app
+
+ARG CSB_VERSION=0.0.0
+RUN GOOS=linux go build -o ./build/cloud-service-broker -ldflags "-X github.com/cloudfoundry/cloud-service-broker/utils.Version=$CSB_VERSION"
+
+# Dockerfile using our hardened base image
+ARG base_image
+
+FROM ${base_image}
+
+COPY --from=build /app/build/cloud-service-broker /bin/cloud-service-broker
+
+ADD https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem /usr/local/share/ca-certificates/
+RUN update-ca-certificates
+
+ENV PORT 8080
+EXPOSE 8080/tcp
+
+WORKDIR /bin
+ENTRYPOINT ["/bin/cloud-service-broker"]
+CMD ["help"]


### PR DESCRIPTION
## Changes proposed in this pull request:

- Build a hardened image for the cloud service broker so we can experiment with it and eventually use it in our environment.
- Related to https://github.com/cloud-gov/product/issues/2943

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Uses our existing process for building a new external project using an internally maintained docker image.