### PR TITLE
Try fixing build by removing workdir

### DIFF
--- a/container/dockerfiles/cloud-service-broker/Dockerfile
+++ b/container/dockerfiles/cloud-service-broker/Dockerfile
@@ -19,6 +19,5 @@ RUN update-ca-certificates
 ENV PORT 8080
 EXPOSE 8080/tcp
 
-WORKDIR /bin
 ENTRYPOINT ["/bin/cloud-service-broker"]
 CMD ["help"]


### PR DESCRIPTION
## Changes proposed in this pull request:

- No other images have WORKDIR set, and Concourse is unable to find inputs for this pipeline only. I suspect WORKDIR is (incorrectly) being used instead of the typical Concourse temp directory.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations
None