### PR TITLE
Fix docker build and usg audit

### DIFF
--- a/ci/container/external/cloud-service-broker/vars.yml
+++ b/ci/container/external/cloud-service-broker/vars.yml
@@ -1,7 +1,8 @@
 base-image: ubuntu-hardened
 base-image-tag: "latest"
 image-repository: cloud-service-broker
-oci-build-params: {}
+oci-build-params:
+  DOCKERFILE: common-dockerfiles/container/dockerfiles/cloud-service-broker/Dockerfile
 src-repo: cloudfoundry/cloud-service-broker
 src-target-branch: main
 common-pipelines-trigger: false

--- a/container/dockerfiles/cloud-service-broker/Dockerfile
+++ b/container/dockerfiles/cloud-service-broker/Dockerfile
@@ -1,3 +1,6 @@
+# Dockerfile using our hardened base image
+ARG base_image
+
 # Adapted from https://github.com/cloudfoundry/cloud-service-broker/blob/main/Dockerfile
 FROM golang:1.22 AS build
 WORKDIR /app
@@ -5,9 +8,6 @@ ADD . /app
 
 ARG CSB_VERSION=0.0.0
 RUN GOOS=linux go build -o ./build/cloud-service-broker -ldflags "-X github.com/cloudfoundry/cloud-service-broker/utils.Version=$CSB_VERSION"
-
-# Dockerfile using our hardened base image
-ARG base_image
 
 FROM ${base_image}
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- base_image arg must be at the top of the Dockerfile. Not sure why.
- DOCKERFILE param is required. Without it, oci-build uses the Dockerfile in the src repo.
- Add the rest of the Dockerfile back now that I've tested it

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None