### PR TITLE
Replace commercial CA cert with GovCloud cert bundle

### DIFF
--- a/container/dockerfiles/cloud-service-broker/Dockerfile
+++ b/container/dockerfiles/cloud-service-broker/Dockerfile
@@ -13,7 +13,9 @@ FROM ${base_image}
 
 COPY --from=build /app/build/cloud-service-broker /bin/cloud-service-broker
 
-ADD https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem /usr/local/share/ca-certificates/
+# Install RDS certificate bundle to support connecting to RDS instances.
+# Link from: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html#UsingWithRDS.SSL.GovCloudCertificates
+ADD https://truststore.pki.us-gov-west-1.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/
 RUN update-ca-certificates
 
 ENV PORT 8080


### PR DESCRIPTION
...since our RDS instance are in GovCloud.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Cert bundle is sourced from an Amazon-owned domain and referenced from their documentation.