### PR TITLE
Set correct extension so certs are detected by update-ca-certificates

### DIFF
--- a/container/dockerfiles/cloud-service-broker/Dockerfile
+++ b/container/dockerfiles/cloud-service-broker/Dockerfile
@@ -16,6 +16,12 @@ COPY --from=build /app/build/cloud-service-broker /bin/cloud-service-broker
 # Install RDS certificate bundle to support connecting to RDS instances.
 # Link from: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html#UsingWithRDS.SSL.GovCloudCertificates
 ADD https://truststore.pki.us-gov-west-1.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/
+# Extension must be .crt for ca-certificates to detect it.
+RUN mv /usr/local/share/ca-certificates/global-bundle.pem /usr/local/share/ca-certificates/global-bundle.crt
+# update-ca-certificates will spuriously output the following:
+# "rehash: warning: skipping global-bundle.pem,it does not contain exactly one certificate or CRL"
+# You can verify that global-bundle.crt was not skipped by grepping /etc/ssl/certs/ca-certificates.crt
+# for the certs from global-bundle.crt in the final image.
 RUN update-ca-certificates
 
 ENV PORT 8080


### PR DESCRIPTION
## Changes proposed in this pull request:

- See title.
- Related to https://github.com/cloud-gov/product/issues/2943

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.