### PR TITLE
use node as base for playwright image

### DIFF
--- a/ci/container/pages/playwright-v1/vars.yml
+++ b/ci/container/pages/playwright-v1/vars.yml
@@ -1,4 +1,4 @@
-base-image: ubuntu-hardened
+base-image: pages-node-v20
 base-image-tag: "latest"
 image-repository: pages-playwright-v1
 oci-build-params: {


### PR DESCRIPTION
## Changes proposed in this pull request:
- use node as base for playwright image

## Security considerations
uses another hardened image as the base