### PR TITLE
add internal pipeline configuration for playwright-python image

### DIFF
--- a/ci/container/internal/playwright-python/vars.yml
+++ b/ci/container/internal/playwright-python/vars.yml
@@ -1,0 +1,9 @@
+base-image: ubuntu-hardened
+base-image-tag: "latest"
+image-repository: playwright-python
+oci-build-params: {}
+src-repo: cloud-gov/playwright-python
+src-target-branch: main
+common-pipelines-trigger: false
+dockerfile-path: []
+dockerfile-trigger: true


### PR DESCRIPTION
## Changes proposed in this pull request:

- add internal pipeline configuration for playwright-python image: https://github.com/cloud-gov/playwright-python

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

This configuration will create the pipeline to generate a hardened image for running Playwright Python in CI
