### PR TITLE
add variable to ensure that playwright-python pipeline is created

### DIFF
--- a/ci/container/pipeline.yml
+++ b/ci/container/pipeline.yml
@@ -24,6 +24,7 @@ jobs:
           - s3-resource
           - github-pr-resource
           - cf-resource
+          - playwright-python
       do:
       - set_pipeline: ((.:name))
         file: src/container/pipeline-internal.yml


### PR DESCRIPTION
## Changes proposed in this pull request:

- see title

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

The playwright-python pipeline will created a hardened image that can be used in CI for running Python Playwright tests
