### PR TITLE
Set BUILD_ENV arg so ZScaler certs are not copied to image

### DIFF
--- a/ci/container/internal/csb/vars.yml
+++ b/ci/container/internal/csb/vars.yml
@@ -1,7 +1,8 @@
 base-image: cloud-service-broker
 base-image-tag: "latest"
 image-repository: csb
-oci-build-params: {}
+oci-build-params:
+  BUILD_ARG_BUILD_ENV: production
 src-repo: cloud-gov/csb
 common-pipelines-trigger: false
 dockerfile-path: []


### PR DESCRIPTION

## Changes proposed in this pull request:

- Related to https://github.com/cloud-gov/product/issues/2943

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.