### PR TITLE
adds oci-build-task

### DIFF
--- a/ci/container/internal/oci-build-task/vars.yml
+++ b/ci/container/internal/oci-build-task/vars.yml
@@ -1,0 +1,8 @@
+base-image: ubuntu-hardened
+base-image-tag: "latest"
+image-repository: oci-build-task
+oci-build-params: {}
+src-repo: cloud-gov/oci-build-task
+common-pipelines-trigger: false
+dockerfile-path: []
+dockerfile-trigger: false

--- a/ci/container/pipeline.yml
+++ b/ci/container/pipeline.yml
@@ -1,80 +1,81 @@
 # job that sets all the rest
 jobs:
-- name: set-self
-  plan:
-    - in_parallel:
+  - name: set-self
+    plan:
+      - in_parallel:
+          - get: src
+            trigger: true
+      - set_pipeline: self
+        file: src/ci/container/pipeline.yml
+
+  - name: set-internal-pipelines
+    plan:
       - get: src
         trigger: true
-    - set_pipeline: self
-      file: src/ci/container/pipeline.yml
+        passed: [set-self]
+      - across:
+          - var: name # repo, pipeline, and image name; all the same.
+            values:
+              - cron-resource
+              - general-task
+              - s3-simple-resource
+              - ubuntu-hardened
+              - slack-notification-resource
+              - s3-resource
+              - github-pr-resource
+              - cf-resource
+              - playwright-python
+              - csb
+              - oci-build-task
+        do:
+          - set_pipeline: ((.:name))
+            file: src/container/pipeline-internal.yml
+            var_files:
+              - src/ci/container/internal/((.:name))/vars.yml
 
-- name: set-internal-pipelines
-  plan:
-    - get: src
-      trigger: true
-      passed: [set-self]
-    - across:
-      - var: name # repo, pipeline, and image name; all the same.
-        values:
-          - cron-resource
-          - general-task
-          - s3-simple-resource
-          - ubuntu-hardened
-          - slack-notification-resource
-          - s3-resource
-          - github-pr-resource
-          - cf-resource
-          - playwright-python
-          - csb
-      do:
-      - set_pipeline: ((.:name))
-        file: src/container/pipeline-internal.yml
-        var_files:
-          - src/ci/container/internal/((.:name))/vars.yml
+  - name: set-external-pipelines
+    plan:
+      - get: src
+        trigger: true
+        passed: [set-self]
+      - across:
+          - var: name # repo, pipeline, and image name; all the same.
+            values:
+              - cf-cli-resource
+              - cloud-service-broker
+              - email-resource
+              - git-resource
+              - registry-image-resource
+              - semver-resource
+              - time-resource
+        do:
+          - set_pipeline: ((.:name))
+            file: src/container/pipeline-external.yml
+            var_files:
+              - src/ci/container/external/((.:name))/vars.yml
 
-- name: set-external-pipelines
-  plan:
-    - get: src
-      trigger: true
-      passed: [set-self]
-    - across:
-      - var: name # repo, pipeline, and image name; all the same.
-        values:
-          - cf-cli-resource
-          - cloud-service-broker
-          - email-resource
-          - git-resource
-          - registry-image-resource
-          - semver-resource
-          - time-resource
-      do:
-      - set_pipeline: ((.:name))
-        file: src/container/pipeline-external.yml
-        var_files:
-          - src/ci/container/external/((.:name))/vars.yml
-
-- name: set-pages-pipelines
-  plan:
-    - get: src
-      trigger: true
-      passed: [set-self]
-    - across:
-      - var: name # repo, pipeline, and image name; all the same.
-        values:
-          - dind-v25
-          - node-v20
-          - python-v3.11
-      do:
-      - set_pipeline: image-((.:name))
-        file: src/container/pipeline-pages.yml
-        team: pages
-        var_files:
-          - src/ci/container/pages/((.:name))/vars.yml
+  - name: set-pages-pipelines
+    plan:
+      - get: src
+        trigger: true
+        passed: [set-self]
+      - across:
+          - var: name # repo, pipeline, and image name; all the same.
+            values:
+              - dind-v25
+              - node-v20
+              - python-v3.11
+        do:
+          - set_pipeline: image-((.:name))
+            file: src/container/pipeline-pages.yml
+            team: pages
+            var_files:
+              - src/ci/container/pages/((.:name))/vars.yml
 
 resources:
-- name: src
-  type: git
-  source:
-    uri: https://github.com/cloud-gov/common-pipelines
-    branch: main
-    commit_verification_keys: ((cloud-gov-pgp-keys))
+  - name: src
+    type: git
+    source:
+      uri: https://github.com/cloud-gov/common-pipelines
+      branch: main
+      commit_verification_keys: ((cloud-gov-pgp-keys))


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add oci-build-task to our internal pipelines

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Adds pipeline to harden another image
