### PR TITLE
Use hardened image

### DIFF
--- a/container/oci-build.yml
+++ b/container/oci-build.yml
@@ -4,19 +4,23 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: concourse/oci-build-task
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: oci-build-task
+    aws_region: us-gov-west-1
+    tag: latest
 
 caches:
-- path: cache
+  - path: cache
 
 inputs:
-- name: src
-- name: base-image
-- name: common-pipelines
-- name: common-dockerfiles
+  - name: src
+  - name: base-image
+  - name: common-pipelines
+  - name: common-dockerfiles
 
 outputs:
-- name: image
+  - name: image
 
 run:
   path: build


### PR DESCRIPTION
## Changes proposed in this pull request:

- Sets pipeline to use hardened oci-build-task image

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Using hardened images meets compliance and security requirements
