### PR TITLE
Support building images on tag instead of commit in source repository

### DIFF
--- a/ci/container/external/cf-cli-resource/vars.yml
+++ b/ci/container/external/cf-cli-resource/vars.yml
@@ -1,11 +1,12 @@
 base-image: ubuntu-hardened
 base-image-tag: "latest"
 image-repository: cf-cli-resource
-oci-build-params: {
+oci-build-params:
   DOCKERFILE: common-dockerfiles/container/dockerfiles/cf-cli-resource/Dockerfile
-}
-src-repo: nulldriver/cf-cli-resource
-src-target-branch: main
+src.source:
+  url: https://github.com/nulldriver/cf-cli-resource
+  branch: main
+  # Since src is a repo outside the cloud-gov org, don't verify commits.
 common-pipelines-trigger: false
 dockerfile-path: ["container/dockerfiles/cf-cli-resource/Dockerfile"]
 dockerfile-trigger: true

--- a/ci/container/external/cloud-service-broker/vars.yml
+++ b/ci/container/external/cloud-service-broker/vars.yml
@@ -3,8 +3,12 @@ base-image-tag: "latest"
 image-repository: cloud-service-broker
 oci-build-params:
   DOCKERFILE: common-dockerfiles/container/dockerfiles/cloud-service-broker/Dockerfile
-src-repo: cloudfoundry/cloud-service-broker
-src-target-branch: main
+src.source:
+  url: https://github.com/cloudfoundry/cloud-service-broker
+  # From https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string.
+  # Modified to start with `^v?` instead of `^`.
+  tag_regex: ^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+  # Since src is a repo outside the cloud-gov org, don't verify commits.
 common-pipelines-trigger: false
 dockerfile-path: ["container/dockerfiles/cloud-service-broker/Dockerfile"]
 dockerfile-trigger: true

--- a/ci/container/external/email-resource/vars.yml
+++ b/ci/container/external/email-resource/vars.yml
@@ -1,11 +1,12 @@
 base-image: ubuntu-hardened
 base-image-tag: "latest"
 image-repository: email-resource
-oci-build-params: {
+oci-build-params:
   DOCKERFILE: common-dockerfiles/container/dockerfiles/email-resource/Dockerfile
-}
-src-repo: pivotal-cf/email-resource
-src-target-branch: master
+src.source:
+  url: https://github.com/pivotal-cf/email-resource
+  branch: master
+  # Since src is a repo outside the cloud-gov org, don't verify commits.
 common-pipelines-trigger: false
 dockerfile-path: ["container/dockerfiles/email-resource/Dockerfile"]
 dockerfile-trigger: true

--- a/ci/container/external/git-resource/vars.yml
+++ b/ci/container/external/git-resource/vars.yml
@@ -4,8 +4,10 @@ image-repository: git-resource
 oci-build-params: {
   DOCKERFILE: common-dockerfiles/container/dockerfiles/git-resource/Dockerfile
 }
-src-repo: concourse/git-resource
-src-target-branch: master
+src.source:
+  url: https://github.com/concourse/git-resource
+  branch: master
+  # Since src is a repo outside the cloud-gov org, don't verify commits.
 common-pipelines-trigger: false
 dockerfile-path: ["container/dockerfiles/git-resource/Dockerfile"]
 dockerfile-trigger: true

--- a/ci/container/external/registry-image-resource/vars.yml
+++ b/ci/container/external/registry-image-resource/vars.yml
@@ -2,8 +2,10 @@ base-image: ubuntu-hardened
 base-image-tag: "latest"
 image-repository: registry-image-resource
 oci-build-params: {}
-src-repo: concourse/registry-image-resource
-src-target-branch: master
+src.source:
+  url: https://github.com/concourse/registry-image-resource
+  branch: master
+  # Since src is a repo outside the cloud-gov org, don't verify commits.
 common-pipelines-trigger: false
 dockerfile-path: []
 dockerfile-trigger: false

--- a/ci/container/external/semver-resource/vars.yml
+++ b/ci/container/external/semver-resource/vars.yml
@@ -1,11 +1,12 @@
 base-image: ubuntu-hardened
 base-image-tag: "latest"
 image-repository: semver-resource
-oci-build-params: {
+oci-build-params:
   DOCKERFILE: common-dockerfiles/container/dockerfiles/semver-resource/Dockerfile
-}
-src-repo: alphagov/paas-semver-resource
-src-target-branch: gds_main
+src.source:
+  url: https://github.com/alphagov/paas-semver-resource
+  branch: gds_main
+  # Since src is a repo outside the cloud-gov org, don't verify commits.
 common-pipelines-trigger: false
 dockerfile-path: ["container/dockerfiles/semver-resource/Dockerfile"]
 dockerfile-trigger: true

--- a/ci/container/external/time-resource/vars.yml
+++ b/ci/container/external/time-resource/vars.yml
@@ -2,8 +2,10 @@ base-image: ubuntu-hardened
 base-image-tag: "latest"
 image-repository: time-resource
 oci-build-params: {}
-src-repo: concourse/time-resource
-src-target-branch: master
+src.source:
+  url: https://github.com/concourse/time-resource
+  branch: master
+  # Since src is a repo outside the cloud-gov org, don't verify commits.
 common-pipelines-trigger: false
 dockerfile-path: []
 dockerfile-trigger: false

--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -153,10 +153,7 @@ resources:
 
 - name: src
   type: git
-  source:
-    uri: https://github.com/((src-repo))
-    branch: ((src-target-branch))
-    # Since src is a repo outside the cloud-gov org, don't verify commits.
+  source: ((src.source))
 
 - name: daily
   type: time


### PR DESCRIPTION
## Changes proposed in this pull request:

- I'd like to be able to build cloud service broker images on each tag instead of each commit, since commits to the main branch can break the build. To support this, I've factored out the `src` repo configuration to the vars files, which allows setting either a branch to watch for every commit, or a tag regex pattern to match against.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.