### PR TITLE
add github-release-resource

### DIFF
--- a/ci/container/internal/github-release-resource/vars.yml
+++ b/ci/container/internal/github-release-resource/vars.yml
@@ -1,0 +1,8 @@
+base-image: ubuntu-hardened
+base-image-tag: "latest"
+image-repository: github-release-resource
+oci-build-params: {}
+src-repo: cloud-gov/github-release-resource
+common-pipelines-trigger: false
+dockerfile-path: []
+dockerfile-trigger: false

--- a/ci/container/pipeline.yml
+++ b/ci/container/pipeline.yml
@@ -28,6 +28,7 @@ jobs:
               - csb
               - oci-build-task
               - bosh-deployment-resource
+              - github-release-resource
         do:
           - set_pipeline: ((.:name))
             file: src/container/pipeline-internal.yml


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds github-release-resource to scanning and hardening pipeline

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Setting up another image for hardening
