### PR TITLE
url should be uri

### DIFF
--- a/ci/container/external/cf-cli-resource/vars.yml
+++ b/ci/container/external/cf-cli-resource/vars.yml
@@ -4,7 +4,7 @@ image-repository: cf-cli-resource
 oci-build-params:
   DOCKERFILE: common-dockerfiles/container/dockerfiles/cf-cli-resource/Dockerfile
 src-source:
-  url: https://github.com/nulldriver/cf-cli-resource
+  uri: https://github.com/nulldriver/cf-cli-resource
   branch: main
   # Since src is a repo outside the cloud-gov org, don't verify commits.
 common-pipelines-trigger: false

--- a/ci/container/external/cloud-service-broker/vars.yml
+++ b/ci/container/external/cloud-service-broker/vars.yml
@@ -4,7 +4,7 @@ image-repository: cloud-service-broker
 oci-build-params:
   DOCKERFILE: common-dockerfiles/container/dockerfiles/cloud-service-broker/Dockerfile
 src-source:
-  url: https://github.com/cloudfoundry/cloud-service-broker
+  uri: https://github.com/cloudfoundry/cloud-service-broker
   # From https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string.
   # Modified to start with `^v?` instead of `^`.
   tag_regex: ^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$

--- a/ci/container/external/email-resource/vars.yml
+++ b/ci/container/external/email-resource/vars.yml
@@ -4,7 +4,7 @@ image-repository: email-resource
 oci-build-params:
   DOCKERFILE: common-dockerfiles/container/dockerfiles/email-resource/Dockerfile
 src-source:
-  url: https://github.com/pivotal-cf/email-resource
+  uri: https://github.com/pivotal-cf/email-resource
   branch: master
   # Since src is a repo outside the cloud-gov org, don't verify commits.
 common-pipelines-trigger: false

--- a/ci/container/external/git-resource/vars.yml
+++ b/ci/container/external/git-resource/vars.yml
@@ -4,7 +4,7 @@ image-repository: git-resource
 oci-build-params:
   DOCKERFILE: common-dockerfiles/container/dockerfiles/git-resource/Dockerfile
 src-source:
-  url: https://github.com/concourse/git-resource
+  uri: https://github.com/concourse/git-resource
   branch: master
   # Since src is a repo outside the cloud-gov org, don't verify commits.
 common-pipelines-trigger: false

--- a/ci/container/external/registry-image-resource/vars.yml
+++ b/ci/container/external/registry-image-resource/vars.yml
@@ -3,7 +3,7 @@ base-image-tag: "latest"
 image-repository: registry-image-resource
 oci-build-params: {}
 src-source:
-  url: https://github.com/concourse/registry-image-resource
+  uri: https://github.com/concourse/registry-image-resource
   branch: master
   # Since src is a repo outside the cloud-gov org, don't verify commits.
 common-pipelines-trigger: false

--- a/ci/container/external/semver-resource/vars.yml
+++ b/ci/container/external/semver-resource/vars.yml
@@ -4,7 +4,7 @@ image-repository: semver-resource
 oci-build-params:
   DOCKERFILE: common-dockerfiles/container/dockerfiles/semver-resource/Dockerfile
 src-source:
-  url: https://github.com/alphagov/paas-semver-resource
+  uri: https://github.com/alphagov/paas-semver-resource
   branch: gds_main
   # Since src is a repo outside the cloud-gov org, don't verify commits.
 common-pipelines-trigger: false

--- a/ci/container/external/time-resource/vars.yml
+++ b/ci/container/external/time-resource/vars.yml
@@ -3,7 +3,7 @@ base-image-tag: "latest"
 image-repository: time-resource
 oci-build-params: {}
 src-source:
-  url: https://github.com/concourse/time-resource
+  uri: https://github.com/concourse/time-resource
   branch: master
   # Since src is a repo outside the cloud-gov org, don't verify commits.
 common-pipelines-trigger: false


### PR DESCRIPTION
## Changes proposed in this pull request:

- git-resource needs uri, not url, to properly grab resources
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Update external pipelines so that getting the src no longer fails
