### PR TITLE
Add bosh io resource

### DIFF
--- a/ci/container/external/bosh-io-release-resource/vars.yml
+++ b/ci/container/external/bosh-io-release-resource/vars.yml
@@ -1,0 +1,11 @@
+base-image: ubuntu-hardened
+base-image-tag: "latest"
+image-repository: bosh-io-release-resource
+oci-build-params: {}
+src-source:
+  uri: https://github.com/concourse/bosh-io-release-resource
+  branch: master
+  # Since src is a repo outside the cloud-gov org, don't verify commits.
+common-pipelines-trigger: false
+dockerfile-path: []
+dockerfile-trigger: false

--- a/ci/container/pipeline.yml
+++ b/ci/container/pipeline.yml
@@ -43,6 +43,7 @@ jobs:
       - across:
           - var: name # repo, pipeline, and image name; all the same.
             values:
+              - bosh-io-release-resource
               - cf-cli-resource
               - cloud-service-broker
               - email-resource


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds pipeline to harden bosh-io-release-resource

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Adds pipeline to harden another image
