### PR TITLE
add pipeline for pulledpork image

### DIFF
--- a/ci/container/internal/pulledpork/vars.yml
+++ b/ci/container/internal/pulledpork/vars.yml
@@ -1,0 +1,10 @@
+base-image: ubuntu-hardened
+base-image-tag: "latest"
+image-repository: pulledpork
+oci-build-params: {
+  DOCKERFILE: src/ci/docker/pulledpork/Dockerfile
+}
+src-repo: cloud-gov/cg-snort-boshrelease
+common-pipelines-trigger: false
+dockerfile-path: []
+dockerfile-trigger: false

--- a/ci/container/pipeline.yml
+++ b/ci/container/pipeline.yml
@@ -29,6 +29,7 @@ jobs:
               - oci-build-task
               - bosh-deployment-resource
               - github-release-resource
+              - pulledpork
         do:
           - set_pipeline: ((.:name))
             file: src/container/pipeline-internal.yml


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds pipeline to harden pulledpork image

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Adding pipeline to harden image
