### PR TITLE
update scan import to include date

### DIFF
--- a/container/import-scan.sh
+++ b/container/import-scan.sh
@@ -12,6 +12,7 @@ curl -X "POST" $DEFECTDOJO_IMPORT_URL \
   -F "verified=true" \
   -F "scan_type=Anchore Grype" \
   -F "product_name=$IMAGENAME" \
-  -F "engagement_name=CVE Scan" \
+  -F "engagement_name=CVE Scan $(date '+%Y-%m-%d')" \
+  -F "engagement_end_date="$(date '+%Y-%m-%d')"
   -F "auto_create_context=true" \
   -F "file=@cves/output.json;type=application/json"


### PR DESCRIPTION
## Changes proposed in this pull request:

- Include date to have easier organization of grype findings in defectdojo

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Adding date to improve organization of findings
