### PR TITLE
add only-fixed flag

### DIFF
--- a/container/scan-image.sh
+++ b/container/scan-image.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-grype image/image.tar -c common-pipelines/container/grype.yaml -q -o json --file cves/output.json
+grype image/image.tar -c common-pipelines/container/grype.yaml --only-fixed -q -o json --file cves/output.json
 grype image/image.tar -c common-pipelines/container/grype.yaml -q -o table --file table.txt
 
 cat cves/output.json | jq '.matches | .[]? |  .vulnerability.severity' >> severity.txt

--- a/container/scan-image.sh
+++ b/container/scan-image.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 grype image/image.tar -c common-pipelines/container/grype.yaml --only-fixed -q -o json --file cves/output.json
-grype image/image.tar -c common-pipelines/container/grype.yaml -q -o table --file table.txt
+grype image/image.tar -c common-pipelines/container/grype.yaml  --only-fixed -q -o table --file table.txt
 
 cat cves/output.json | jq '.matches | .[]? |  .vulnerability.severity' >> severity.txt
 

--- a/container/scan-image.sh
+++ b/container/scan-image.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 grype image/image.tar -c common-pipelines/container/grype.yaml --only-fixed -q -o json --file cves/output.json
-grype image/image.tar -c common-pipelines/container/grype.yaml  --only-fixed -q -o table --file table.txt
+grype image/image.tar -c common-pipelines/container/grype.yaml --only-fixed -q -o table --file table.txt
 
 cat cves/output.json | jq '.matches | .[]? |  .vulnerability.severity' >> severity.txt
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Use only-fixed flag

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Adds flag to show only vulns with fixes available
