### PR TITLE
update import scan to close old findings across product

### DIFF
--- a/container/import-scan.sh
+++ b/container/import-scan.sh
@@ -15,4 +15,5 @@ curl -X "POST" $DEFECTDOJO_IMPORT_URL \
   -F "engagement_name=CVE Scan $(date '+%Y-%m-%d')" \
   -F "engagement_end_date=$(date '+%Y-%m-%d')" \
   -F "auto_create_context=true" \
+  -F "close_old_findings_product_scope=true" \
   -F "file=@cves/output.json;type=application/json"


### PR DESCRIPTION
## Changes proposed in this pull request:

- This setting is needed to close old findings that were seen in old scans but are no longer found in new scans

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Fixing scan import to close old findings
