### PR TITLE
chore: bump dind major version

### DIFF
--- a/ci/container/pages/dind/vars.yml
+++ b/ci/container/pages/dind/vars.yml
@@ -1,9 +1,7 @@
 base-image: ubuntu-hardened
 base-image-tag: "latest"
-image-repository: pages-dind-v25
-oci-build-params: {
-  CONTEXT: src/dind/v25
-}
+image-repository: pages-dind
+oci-build-params: { CONTEXT: src/dind/v27 }
 src-repo: cloud-gov/pages-images
 src-target-branch: main
 common-pipelines-trigger: false

--- a/ci/container/pipeline.yml
+++ b/ci/container/pipeline.yml
@@ -68,7 +68,7 @@ jobs:
       - across:
           - var: name # repo, pipeline, and image name; all the same.
             values:
-              - dind-v25
+              - dind
               - node-v20
               - python-v3.11
               - redis-v7.2


### PR DESCRIPTION
## Changes proposed in this pull request:
- Bump versions associated with the docker in docker image

## Security considerations
Updates to the latest version of Docker Engine