### PR TITLE
Upload ConMon scans to s3

### DIFF
--- a/container/conmon-scan.sh
+++ b/container/conmon-scan.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Generates XML formatted report
-grype image/image.tar -c common-pipelines/container/grype.yaml --only-fixed -q -o cyclonedx --file conmon-can/$IMAGENAME.xml
+grype image/image.tar -c common-pipelines/container/grype.yaml --only-fixed -q -o cyclonedx --file conmon-scan/$IMAGENAME.xml

--- a/container/conmon-scan.sh
+++ b/container/conmon-scan.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Generates XML formatted report
+grype image/image.tar -c common-pipelines/container/grype.yaml --only-fixed -q -o cyclonedx --file cves/output.xml

--- a/container/conmon-scan.sh
+++ b/container/conmon-scan.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Generates XML formatted report
-grype image/image.tar -c common-pipelines/container/grype.yaml --only-fixed -q -o cyclonedx --file cves/output.xml
+grype image/image.tar -c common-pipelines/container/grype.yaml --only-fixed -q -o cyclonedx --file conmon-can/$IMAGENAME.xml

--- a/container/conmon-scan.yml
+++ b/container/conmon-scan.yml
@@ -19,4 +19,4 @@ outputs:
 - name: cves
 
 run:
-  path: common-pipelines/container/scan-image.sh
+  path: common-pipelines/container/conmon-scan.sh

--- a/container/conmon-scan.yml
+++ b/container/conmon-scan.yml
@@ -1,7 +1,6 @@
 ---
 platform: linux
 
-#cannot be factored out because it intereferes with oci-build-task output
 image_resource:
   type: registry-image
   source:

--- a/container/conmon-scan.yml
+++ b/container/conmon-scan.yml
@@ -16,7 +16,10 @@ inputs:
 - name: image
 
 outputs:
-- name: cves
+- name: conmon-scan
 
 run:
   path: common-pipelines/container/conmon-scan.sh
+
+params:
+  IMAGENAME:

--- a/container/conmon-scan.yml
+++ b/container/conmon-scan.yml
@@ -1,0 +1,22 @@
+---
+platform: linux
+
+#cannot be factored out because it intereferes with oci-build-task output
+image_resource:
+  type: registry-image
+  source:
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: general-task
+    aws_region: us-gov-west-1
+    tag: latest
+
+inputs:
+- name: common-pipelines
+- name: image
+
+outputs:
+- name: cves
+
+run:
+  path: common-pipelines/container/scan-image.sh

--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -110,6 +110,51 @@ jobs:
           <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
         channel: ((slack-channel-success))
 
+  - name: conmon-scan
+    plan:
+      - in_parallel:
+          - get: image
+            trigger: false
+            params:
+              format: oci
+
+          - get: common-pipelines
+            trigger: false
+
+          - get: monthly
+            trigger: true
+
+          - get: general-task
+
+          - get: conmon-scan-file
+
+      - task: conmon-scan
+        file: common-pipelines/container/conmon-scan.yml
+        params:
+          IMAGENAME: ((image-repository))
+
+      - put: conmon-scan-file
+        tags: [iaas]
+        params:
+          file: conmon-scan/((image-repository)).xml
+
+    on_failure:
+      put: slack
+      params:
+        <<: *slack-failure-params
+        text: |
+          :x: ConMon Scan of `$BUILD_PIPELINE_NAME` FAILED
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+
+    on_success:
+      put: slack
+      params:
+        <<: *slack-failure-params
+        text: |
+          :white_check_mark: ConMon Scan of `$BUILD_PIPELINE_NAME` ran SUCCESSFULLY
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: ((slack-channel-success))
+
 resources:
   - name: base-image
     type: registry-image
@@ -160,6 +205,13 @@ resources:
     source:
       interval: 24h
 
+  - name: monthly
+    type: cron-resource
+    source:
+      expression: "0 6 22 * *"
+      location: "America/New_York"
+      fire_immediately: true
+
   - name: general-task
     type: registry-image
     source:
@@ -168,6 +220,15 @@ resources:
       repository: general-task
       aws_region: us-gov-west-1
       tag: latest
+
+  - name: conmon-scan-file
+    type: s3-iam
+    source:
+      bucket: ((container_scans_bucket))
+      versioned_file: conmon-scan/((image-repository)).xml
+      region_name: us-gov-west-1
+      server_side_encryption: AES256
+      initial_version: conmon-scan/((image-repository)).xml
 
 resource_types:
   - name: registry-image
@@ -185,5 +246,23 @@ resource_types:
       aws_access_key_id: ((ecr_aws_key))
       aws_secret_access_key: ((ecr_aws_secret))
       repository: slack-notification-resource
+      aws_region: us-gov-west-1
+      tag: latest
+
+  - name: s3-iam
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: s3-resource
+      aws_region: us-gov-west-1
+      tag: latest
+
+  - name: cron-resource
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: cron-resource
       aws_region: us-gov-west-1
       tag: latest

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -192,25 +192,25 @@ jobs:
       - task: conmon-scan
         file: common-pipelines/container/conmon-scan.yml
 
-      on_failure:
-        put: slack
-        params:
-          <<: *slack-failure-params
-          text: |
-            :x: ConMon Scan of `$BUILD_PIPELINE_NAME` FAILED
-            <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      on_success:
-        do:
-          - put: conmon-scan-file
-            params:
-              file: cves/output.xml
-          - put: slack
-            params:
-              <<: *slack-failure-params
-              text: |
-                :white_check_mark: ConMon Scan of `$BUILD_PIPELINE_NAME` ran SUCCESSFULLY
-                <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-              channel: ((slack-channel-success))
+        on_failure:
+          put: slack
+          params:
+            <<: *slack-failure-params
+            text: |
+              :x: ConMon Scan of `$BUILD_PIPELINE_NAME` FAILED
+              <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        on_success:
+          do:
+            - put: conmon-scan-file
+              params:
+                file: cves/output.xml
+            - put: slack
+              params:
+                <<: *slack-failure-params
+                text: |
+                  :white_check_mark: ConMon Scan of `$BUILD_PIPELINE_NAME` ran SUCCESSFULLY
+                  <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+                channel: ((slack-channel-success))
 
 resources:
   - name: base-image

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -171,6 +171,47 @@ jobs:
           <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
         channel: ((slack-channel-success))
 
+  - name: conmon-scan
+    plan:
+      - in_parallel:
+          - get: image
+            trigger: false
+            params:
+              format: oci
+
+          - get: common-pipelines
+            trigger: false
+
+          - get: monthly
+            trigger: true
+
+          - get: conmon-scan-file
+
+          - get: general-task
+
+      - task: conmon-scan
+        file: common-pipelines/container/conmon-scan.yml
+
+      on_failure:
+        put: slack
+        params:
+          <<: *slack-failure-params
+          text: |
+            :x: ConMon Scan of `$BUILD_PIPELINE_NAME` FAILED
+            <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      on_success:
+        do:
+          - put: conmon-scan-file
+            params:
+              file: cves/output.xml
+          - put: slack
+            params:
+              <<: *slack-failure-params
+              text: |
+                :white_check_mark: ConMon Scan of `$BUILD_PIPELINE_NAME` ran SUCCESSFULLY
+                <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+              channel: ((slack-channel-success))
+
 resources:
   - name: base-image
     type: registry-image
@@ -233,6 +274,13 @@ resources:
     source:
       interval: 24h
 
+  - name: monthly
+    type: cron-resource
+    source:
+      expression: "0 6 22 * *"
+      location: "America/New_York"
+      fire_immediately: true
+
   - name: general-task
     type: registry-image
     source:
@@ -241,6 +289,14 @@ resources:
       repository: general-task
       aws_region: us-gov-west-1
       tag: latest
+
+  - name: conmon-scan-file
+    type: s3-iam
+    source:
+      bucket: ((container_scans_bucket))
+      versioned_file: ((image-repository)).xml
+      initial_version: ((image-repository)).xml
+      region_name: us-gov-west-1
 
 resource_types:
   - name: registry-image
@@ -267,5 +323,23 @@ resource_types:
       aws_access_key_id: ((ecr_aws_key))
       aws_secret_access_key: ((ecr_aws_secret))
       repository: github-pr-resource
+      aws_region: us-gov-west-1
+      tag: latest
+
+  - name: s3-iam
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: s3-resource
+      aws_region: us-gov-west-1
+      tag: latest
+
+  - name: cron-resource
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: cron-resource
       aws_region: us-gov-west-1
       tag: latest

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -199,6 +199,23 @@ jobs:
         params:
           file: conmon-scan/((image-repository)).xml
 
+    on_failure:
+      put: slack
+      params:
+        <<: *slack-failure-params
+        text: |
+          :x: ConMon Scan of `$BUILD_PIPELINE_NAME` FAILED
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+
+    on_success:
+      put: slack
+      params:
+        <<: *slack-failure-params
+        text: |
+          :white_check_mark: ConMon Scan of `$BUILD_PIPELINE_NAME` ran SUCCESSFULLY
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: ((slack-channel-success))
+
 resources:
   - name: base-image
     type: registry-image

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -187,12 +187,15 @@ jobs:
 
           - get: general-task
 
+          - get: conmon-scan-file
+
       - task: conmon-scan
         file: common-pipelines/container/conmon-scan.yml
         params:
           IMAGENAME: ((image-repository))
 
       - put: conmon-scan-file
+        tags: [iaas]
         params:
           file: conmon-scan/((image-repository)).xml
 
@@ -281,6 +284,7 @@ resources:
       versioned_file: conmon-scan/((image-repository)).xml
       region_name: us-gov-west-1
       server_side_encryption: AES256
+      initial_version: conmon-scan/((image-repository)).xml
 
 resource_types:
   - name: registry-image

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -185,32 +185,16 @@ jobs:
           - get: monthly
             trigger: true
 
-          - get: conmon-scan-file
-
           - get: general-task
 
       - task: conmon-scan
         file: common-pipelines/container/conmon-scan.yml
+        params:
+          IMAGENAME: ((image-repository))
 
-        on_failure:
-          put: slack
-          params:
-            <<: *slack-failure-params
-            text: |
-              :x: ConMon Scan of `$BUILD_PIPELINE_NAME` FAILED
-              <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-        on_success:
-          do:
-            - put: conmon-scan-file
-              params:
-                file: cves/output.xml
-            - put: slack
-              params:
-                <<: *slack-failure-params
-                text: |
-                  :white_check_mark: ConMon Scan of `$BUILD_PIPELINE_NAME` ran SUCCESSFULLY
-                  <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-                channel: ((slack-channel-success))
+      - put: conmon-scan-file
+        params:
+          file: conmon-scan/((image-repository)).xml
 
 resources:
   - name: base-image
@@ -294,9 +278,9 @@ resources:
     type: s3-iam
     source:
       bucket: ((container_scans_bucket))
-      versioned_file: ((image-repository)).xml
-      initial_version: ((image-repository)).xml
+      versioned_file: conmon-scan/((image-repository)).xml
       region_name: us-gov-west-1
+      server_side_encryption: AES256
 
 resource_types:
   - name: registry-image

--- a/container/pipeline-pages.yml
+++ b/container/pipeline-pages.yml
@@ -164,6 +164,51 @@ jobs:
         username: ((slack-username))
         icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 
+  - name: conmon-scan
+    plan:
+      - in_parallel:
+          - get: image
+            trigger: false
+            params:
+              format: oci
+
+          - get: common-pipelines
+            trigger: false
+
+          - get: monthly
+            trigger: true
+
+          - get: general-task
+
+          - get: conmon-scan-file
+
+      - task: conmon-scan
+        file: common-pipelines/container/conmon-scan.yml
+        params:
+          IMAGENAME: ((image-repository))
+
+      - put: conmon-scan-file
+        tags: [iaas]
+        params:
+          file: conmon-scan/((image-repository)).xml
+
+    on_failure:
+      put: slack
+      params:
+        <<: *slack-failure-params
+        text: |
+          :x: ConMon Scan of `$BUILD_PIPELINE_NAME` FAILED
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+
+    on_success:
+      put: slack
+      params:
+        <<: *slack-failure-params
+        text: |
+          :white_check_mark: ConMon Scan of `$BUILD_PIPELINE_NAME` ran SUCCESSFULLY
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: ((slack-channel-success))
+
 resources:
   - name: base-image
     type: registry-image
@@ -223,6 +268,13 @@ resources:
     source:
       interval: 24h
 
+  - name: monthly
+    type: cron-resource
+    source:
+      expression: "0 6 22 * *"
+      location: "America/New_York"
+      fire_immediately: true
+
   - name: general-task
     type: registry-image
     source:
@@ -231,6 +283,15 @@ resources:
       repository: general-task
       aws_region: us-gov-west-1
       tag: latest
+
+  - name: conmon-scan-file
+    type: s3-iam
+    source:
+      bucket: ((container_scans_bucket))
+      versioned_file: conmon-scan/((image-repository)).xml
+      region_name: us-gov-west-1
+      server_side_encryption: AES256
+      initial_version: conmon-scan/((image-repository)).xml
 
 resource_types:
   - name: pull-request
@@ -257,5 +318,23 @@ resource_types:
       aws_access_key_id: ((ecr_aws_key))
       aws_secret_access_key: ((ecr_aws_secret))
       repository: slack-notification-resource
+      aws_region: us-gov-west-1
+      tag: latest
+
+  - name: s3-iam
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: s3-resource
+      aws_region: us-gov-west-1
+      tag: latest
+
+  - name: cron-resource
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: cron-resource
       aws_region: us-gov-west-1
       tag: latest


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds a job to internal, external, and pages pipelines to upload the grype xml report to s3 each month

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Storing grype scans in s3
