### PR TITLE
remove iaas tag

### DIFF
--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -134,7 +134,6 @@ jobs:
           IMAGENAME: ((image-repository))
 
       - put: conmon-scan-file
-        tags: [iaas]
         params:
           file: conmon-scan/((image-repository)).xml
 

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -195,7 +195,6 @@ jobs:
           IMAGENAME: ((image-repository))
 
       - put: conmon-scan-file
-        tags: [iaas]
         params:
           file: conmon-scan/((image-repository)).xml
 

--- a/container/pipeline-pages.yml
+++ b/container/pipeline-pages.yml
@@ -188,7 +188,6 @@ jobs:
           IMAGENAME: ((image-repository))
 
       - put: conmon-scan-file
-        tags: [iaas]
         params:
           file: conmon-scan/((image-repository)).xml
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Remove iaas tag as it is no longer needed

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Removing the iaas tag after updating concourse permissions
