### PR TITLE
Patch CF CLI to newest for v8, 8.8.0

### DIFF
--- a/container/dockerfiles/cf-cli-resource/Dockerfile
+++ b/container/dockerfiles/cf-cli-resource/Dockerfile
@@ -28,7 +28,7 @@ RUN mkdir -p /opt/cf-cli-${CF_CLI_7_VERSION} \
   | tar -zxC /opt/cf-cli-${CF_CLI_7_VERSION} \
   && ln -s /opt/cf-cli-${CF_CLI_7_VERSION}/cf7 /usr/local/bin
 
-ARG CF_CLI_8_VERSION=8.7.10
+ARG CF_CLI_8_VERSION=8.8.0
 RUN mkdir -p /opt/cf-cli-${CF_CLI_8_VERSION} \
   && curl -SL "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_8_VERSION}" \
   | tar -zxC /opt/cf-cli-${CF_CLI_8_VERSION} \


### PR DESCRIPTION
## Changes proposed in this pull request:

- Patch the CF CLI v8 version which uses `golang.org/x/net v0.28.0`, the older version 0.22.0 is being flagged by DD
- The original DD scan only noted the v7 file location.  Had to patch and rerun to find the second location, hence this PR
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Moves to a more recent version of the CF CLI to be used in the concourse containers