### PR TITLE
use hardened images

### DIFF
--- a/container/oci-build.yml
+++ b/container/oci-build.yml
@@ -4,7 +4,11 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: concourse/oci-build-task
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: oci-build-task
+    aws_region: us-gov-west-1
+    tag: latest
 
 caches:
 - path: cache

--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -283,12 +283,3 @@ resource_types:
       repository: time-resource
       aws_region: us-gov-west-1
       tag: latest
-
-  - name: oci-build-task
-    type: registry-image
-    source:
-      aws_access_key_id: ((ecr_aws_key))
-      aws_secret_access_key: ((ecr_aws_secret))
-      repository: oci-build-task
-      aws_region: us-gov-west-1
-      tag: latest

--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -283,3 +283,12 @@ resource_types:
       repository: time-resource
       aws_region: us-gov-west-1
       tag: latest
+
+  - name: oci-build-task
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: oci-build-task
+      aws_region: us-gov-west-1
+      tag: latest

--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -265,3 +265,21 @@ resource_types:
       repository: cron-resource
       aws_region: us-gov-west-1
       tag: latest
+
+  - name: git
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: git-resource
+      aws_region: us-gov-west-1
+      tag: latest
+
+  - name: time
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: time-resource
+      aws_region: us-gov-west-1
+      tag: latest

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -365,12 +365,3 @@ resource_types:
       repository: time-resource
       aws_region: us-gov-west-1
       tag: latest
-
-  - name: oci-build-task
-    type: registry-image
-    source:
-      aws_access_key_id: ((ecr_aws_key))
-      aws_secret_access_key: ((ecr_aws_secret))
-      repository: oci-build-task
-      aws_region: us-gov-west-1
-      tag: latest

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -347,3 +347,21 @@ resource_types:
       repository: cron-resource
       aws_region: us-gov-west-1
       tag: latest
+
+  - name: git
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: git-resource
+      aws_region: us-gov-west-1
+      tag: latest
+
+  - name: time
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: time-resource
+      aws_region: us-gov-west-1
+      tag: latest

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -365,3 +365,12 @@ resource_types:
       repository: time-resource
       aws_region: us-gov-west-1
       tag: latest
+
+  - name: oci-build-task
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: oci-build-task
+      aws_region: us-gov-west-1
+      tag: latest

--- a/container/pipeline-pages.yml
+++ b/container/pipeline-pages.yml
@@ -358,12 +358,3 @@ resource_types:
       repository: time-resource
       aws_region: us-gov-west-1
       tag: latest
-
-  - name: oci-build-task
-    type: registry-image
-    source:
-      aws_access_key_id: ((ecr_aws_key))
-      aws_secret_access_key: ((ecr_aws_secret))
-      repository: oci-build-task
-      aws_region: us-gov-west-1
-      tag: latest

--- a/container/pipeline-pages.yml
+++ b/container/pipeline-pages.yml
@@ -358,3 +358,12 @@ resource_types:
       repository: time-resource
       aws_region: us-gov-west-1
       tag: latest
+
+  - name: oci-build-task
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: oci-build-task
+      aws_region: us-gov-west-1
+      tag: latest

--- a/container/pipeline-pages.yml
+++ b/container/pipeline-pages.yml
@@ -340,3 +340,21 @@ resource_types:
       repository: cron-resource
       aws_region: us-gov-west-1
       tag: latest
+
+  - name: git
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: git-resource
+      aws_region: us-gov-west-1
+      tag: latest
+
+  - name: time
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: time-resource
+      aws_region: us-gov-west-1
+      tag: latest


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updates remaining resource to use hardened images

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Use hardened images
