### PR TITLE
Add external domain broker

### DIFF
--- a/ci/container/internal/external-domain-broker-testing/vars.yml
+++ b/ci/container/internal/external-domain-broker-testing/vars.yml
@@ -1,6 +1,6 @@
 base-image: ubuntu-hardened
 base-image-tag: "latest"
-image-repository: external-domain-broker
+image-repository: external-domain-broker-testing
 oci-build-params: {
   DOCKERFILE: src/docker/Dockerfile.dev
 }

--- a/ci/container/internal/external-domain-broker-testing/vars.yml
+++ b/ci/container/internal/external-domain-broker-testing/vars.yml
@@ -5,7 +5,7 @@ oci-build-params: {
   DOCKERFILE: src/docker/Dockerfile.dev
 }
 src-repo: cloud-gov/external-domain-broker
-src-target-branch: master
+src-target-branch: main
 common-pipelines-trigger: false
 dockerfile-path: []
 dockerfile-trigger: false

--- a/ci/container/internal/external-domain-broker/vars.yml
+++ b/ci/container/internal/external-domain-broker/vars.yml
@@ -1,0 +1,11 @@
+base-image: ubuntu-hardened
+base-image-tag: "latest"
+image-repository: external-domain-broker
+oci-build-params: {
+  DOCKERFILE: src/docker/Dockerfile.dev
+}
+src-repo: cloud-gov/external-domain-broker
+src-target-branch: master
+common-pipelines-trigger: false
+dockerfile-path: []
+dockerfile-trigger: false

--- a/ci/container/pipeline.yml
+++ b/ci/container/pipeline.yml
@@ -30,7 +30,7 @@ jobs:
               - bosh-deployment-resource
               - github-release-resource
               - pulledpork
-              - external-domain-broker
+              - external-domain-broker-testing
         do:
           - set_pipeline: ((.:name))
             file: src/container/pipeline-internal.yml

--- a/ci/container/pipeline.yml
+++ b/ci/container/pipeline.yml
@@ -30,6 +30,7 @@ jobs:
               - bosh-deployment-resource
               - github-release-resource
               - pulledpork
+              - external-domain-broker
         do:
           - set_pipeline: ((.:name))
             file: src/container/pipeline-internal.yml


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds a pipeline to harden the image used in the external-domain-broker repo

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Hardening another image
