### PR TITLE
Fix audit image script

### DIFF
--- a/container/usg-audit.sh
+++ b/container/usg-audit.sh
@@ -27,7 +27,7 @@ apt-get -y -qq install usg
 
 echo "installing bs4"
 # Install the python library BeautifulSoup to parse html
-pip3 install beautifulsoup4
+python3 -m pip install beautifulsoup4
 
 # Run cis audit and put html results into cis-audit.html file
 echo "running audit"

--- a/container/usg-audit.yml
+++ b/container/usg-audit.yml
@@ -9,6 +9,7 @@ outputs:
 
 run:
   path: common-pipelines/container/usg-audit.sh
+  user: root
 
 params:
   # Required for running 'usg' audit tool.


### PR DESCRIPTION
## Changes proposed in this pull request:

- Set the script to run as root in case there's an image that starts up as another user
- Use `python3 -m pip` so that bs4 is installed properly for use by the script

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Fixing the audit script to work for all images, regardless of user
