### PR TITLE
removes the fire_immediately param

### DIFF
--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -209,7 +209,6 @@ resources:
     source:
       expression: "0 6 22 * *"
       location: "America/New_York"
-      fire_immediately: true
 
   - name: general-task
     type: registry-image

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -282,7 +282,6 @@ resources:
     source:
       expression: "0 6 22 * *"
       location: "America/New_York"
-      fire_immediately: true
 
   - name: general-task
     type: registry-image

--- a/container/pipeline-pages.yml
+++ b/container/pipeline-pages.yml
@@ -275,7 +275,6 @@ resources:
     source:
       expression: "0 6 22 * *"
       location: "America/New_York"
-      fire_immediately: true
 
   - name: general-task
     type: registry-image


### PR DESCRIPTION
## Changes proposed in this pull request:

- Removes the fire_immediately param from the `monthly` resource so that it doesn't fire every time we update the pipeline
- We only want the job to run once a month

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Updating `monthly` resource
