### PR TITLE
Always use latest golang 1.x image to build cloud-service-broker

### DIFF
--- a/container/dockerfiles/cloud-service-broker/Dockerfile
+++ b/container/dockerfiles/cloud-service-broker/Dockerfile
@@ -2,7 +2,7 @@
 ARG base_image
 
 # Adapted from https://github.com/cloudfoundry/cloud-service-broker/blob/main/Dockerfile
-FROM golang:1.22 AS build
+FROM golang:1 AS build
 WORKDIR /app
 ADD . /app
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Upstream can change their required Go version in go.mod, breaking our build unless we always use the latest version.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.