### PR TITLE
adding pipeline for external-domain-broker-migrator-testing image

### DIFF
--- a/ci/container/internal/external-domain-broker-migrator-testing/vars.yml
+++ b/ci/container/internal/external-domain-broker-migrator-testing/vars.yml
@@ -1,0 +1,11 @@
+base-image: ubuntu-hardened
+base-image-tag: "latest"
+image-repository: external-domain-broker-migrator-testing
+oci-build-params: {
+  DOCKERFILE: src/docker/Dockerfile.dev
+}
+src-repo: cloud-gov/external-domain-broker-migrator
+src-target-branch: main
+common-pipelines-trigger: false
+dockerfile-path: []
+dockerfile-trigger: false

--- a/ci/container/pipeline.yml
+++ b/ci/container/pipeline.yml
@@ -31,6 +31,7 @@ jobs:
               - github-release-resource
               - pulledpork
               - external-domain-broker-testing
+              - external-domain-broker-migrator-testing
         do:
           - set_pipeline: ((.:name))
             file: src/container/pipeline-internal.yml


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds pipeline for the external-domain-broker-migrator-testing image

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Adding another hardened image