### PR TITLE
update ubuntu-hardened pipeline trigger

### DIFF
--- a/ci/container/internal/ubuntu-hardened/vars.yml
+++ b/ci/container/internal/ubuntu-hardened/vars.yml
@@ -3,6 +3,6 @@ base-image-tag: "22.04"
 image-repository: ubuntu-hardened
 oci-build-params: {}
 src-repo: cloud-gov/ubuntu-hardened
-common-pipelines-trigger: true
+common-pipelines-trigger: false
 dockerfile-path: []
 dockerfile-trigger: false


### PR DESCRIPTION
## Changes proposed in this pull request:

- The `ubuntu-hardened` pipeline would trigger whenever an update was made to the common-pipelines repo. This doesn't seem necessary, so this removes that trigger

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Turn off trigger for ubuntu-hardened pipeline
