### PR TITLE
add openresty to list of pipelines

### DIFF
--- a/ci/container/pipeline.yml
+++ b/ci/container/pipeline.yml
@@ -57,6 +57,7 @@ jobs:
               - registry-image-resource
               - semver-resource
               - time-resource
+              - openresty
         do:
           - set_pipeline: ((.:name))
             file: src/container/pipeline-external.yml


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds openresty to list of external pipelines to build

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Add openresty pipeline
