### PR TITLE
Make configuring pipelines simpler by factoring out common vars

### DIFF
--- a/ci/container/internal/base_vars.yml
+++ b/ci/container/internal/base_vars.yml
@@ -1,0 +1,6 @@
+base-image: ubuntu-hardened
+base-image-tag: latest
+oci-build-params: {}
+common-pipelines-trigger: false
+dockerfile-path: []
+dockerfile-trigger: false

--- a/ci/container/internal/bosh-deployment-resource/vars.yml
+++ b/ci/container/internal/bosh-deployment-resource/vars.yml
@@ -1,8 +1,2 @@
-base-image: ubuntu-hardened
-base-image-tag: "latest"
 image-repository: bosh-deployment-resource
-oci-build-params: {}
 src-repo: cloud-gov/bosh-deployment-resource
-common-pipelines-trigger: false
-dockerfile-path: []
-dockerfile-trigger: false

--- a/ci/container/internal/cf-resource/vars.yml
+++ b/ci/container/internal/cf-resource/vars.yml
@@ -1,11 +1,4 @@
-base-image: ubuntu-hardened
-base-image-tag: "latest"
 image-repository: cf-resource
-oci-build-params: {
-  DOCKERFILE: src/dockerfiles/ubuntu/Dockerfile
-}
+oci-build-params: { DOCKERFILE: src/dockerfiles/ubuntu/Dockerfile }
 src-repo: cloud-gov/cf-resource
 src-target-branch: master
-common-pipelines-trigger: false
-dockerfile-path: []
-dockerfile-trigger: false

--- a/ci/container/internal/concourse-http-jq-resource/vars.yml
+++ b/ci/container/internal/concourse-http-jq-resource/vars.yml
@@ -1,8 +1,2 @@
-base-image: ubuntu-hardened
-base-image-tag: "latest"
 image-repository: concourse-http-jq-resource
-oci-build-params: {}
 src-repo: cloud-gov/concourse-http-jq-resource
-common-pipelines-trigger: false
-dockerfile-path: []
-dockerfile-trigger: false

--- a/ci/container/internal/cron-resource/vars.yml
+++ b/ci/container/internal/cron-resource/vars.yml
@@ -1,8 +1,2 @@
-base-image: ubuntu-hardened
-base-image-tag: "latest"
 image-repository: cron-resource
-oci-build-params: {}
 src-repo: cloud-gov/cron-resource
-common-pipelines-trigger: false
-dockerfile-path: []
-dockerfile-trigger: false

--- a/ci/container/internal/csb/vars.yml
+++ b/ci/container/internal/csb/vars.yml
@@ -4,6 +4,3 @@ image-repository: csb
 oci-build-params:
   BUILD_ARG_BUILD_ENV: production
 src-repo: cloud-gov/csb
-common-pipelines-trigger: false
-dockerfile-path: []
-dockerfile-trigger: false

--- a/ci/container/internal/external-domain-broker-migrator-testing/vars.yml
+++ b/ci/container/internal/external-domain-broker-migrator-testing/vars.yml
@@ -1,11 +1,4 @@
-base-image: ubuntu-hardened
-base-image-tag: "latest"
 image-repository: external-domain-broker-migrator-testing
-oci-build-params: {
-  DOCKERFILE: src/docker/Dockerfile.dev
-}
+oci-build-params: { DOCKERFILE: src/docker/Dockerfile.dev }
 src-repo: cloud-gov/external-domain-broker-migrator
 src-target-branch: main
-common-pipelines-trigger: false
-dockerfile-path: []
-dockerfile-trigger: false

--- a/ci/container/internal/external-domain-broker-testing/vars.yml
+++ b/ci/container/internal/external-domain-broker-testing/vars.yml
@@ -1,11 +1,4 @@
-base-image: ubuntu-hardened
-base-image-tag: "latest"
 image-repository: external-domain-broker-testing
-oci-build-params: {
-  DOCKERFILE: src/docker/Dockerfile.dev
-}
+oci-build-params: { DOCKERFILE: src/docker/Dockerfile.dev }
 src-repo: cloud-gov/external-domain-broker
 src-target-branch: main
-common-pipelines-trigger: false
-dockerfile-path: []
-dockerfile-trigger: false

--- a/ci/container/internal/general-task/vars.yml
+++ b/ci/container/internal/general-task/vars.yml
@@ -1,8 +1,2 @@
-base-image: ubuntu-hardened
-base-image-tag: "latest"
 image-repository: general-task
-oci-build-params: {}
 src-repo: cloud-gov/general-task
-common-pipelines-trigger: false
-dockerfile-path: []
-dockerfile-trigger: false

--- a/ci/container/internal/github-pr-resource/vars.yml
+++ b/ci/container/internal/github-pr-resource/vars.yml
@@ -1,8 +1,2 @@
-base-image: ubuntu-hardened
-base-image-tag: "latest"
 image-repository: github-pr-resource
-oci-build-params: {}
 src-repo: cloud-gov/github-pr-resource
-common-pipelines-trigger: false
-dockerfile-path: []
-dockerfile-trigger: false

--- a/ci/container/internal/github-release-resource/vars.yml
+++ b/ci/container/internal/github-release-resource/vars.yml
@@ -1,8 +1,2 @@
-base-image: ubuntu-hardened
-base-image-tag: "latest"
 image-repository: github-release-resource
-oci-build-params: {}
 src-repo: cloud-gov/github-release-resource
-common-pipelines-trigger: false
-dockerfile-path: []
-dockerfile-trigger: false

--- a/ci/container/internal/legacy-domain-certificate-renewer-testing/vars.yml
+++ b/ci/container/internal/legacy-domain-certificate-renewer-testing/vars.yml
@@ -1,11 +1,4 @@
-base-image: ubuntu-hardened
-base-image-tag: "latest"
 image-repository: legacy-domain-certificate-renewer-testing
-oci-build-params: {
-  DOCKERFILE: src/docker/Dockerfile.dev
-}
+oci-build-params: { DOCKERFILE: src/docker/Dockerfile.dev }
 src-repo: cloud-gov/legacy-domain-certificate-renewer
 src-target-branch: main
-common-pipelines-trigger: false
-dockerfile-path: []
-dockerfile-trigger: false

--- a/ci/container/internal/oci-build-task/vars.yml
+++ b/ci/container/internal/oci-build-task/vars.yml
@@ -1,8 +1,2 @@
-base-image: ubuntu-hardened
-base-image-tag: "latest"
 image-repository: oci-build-task
-oci-build-params: {}
 src-repo: cloud-gov/oci-build-task
-common-pipelines-trigger: false
-dockerfile-path: []
-dockerfile-trigger: false

--- a/ci/container/internal/playwright-python/vars.yml
+++ b/ci/container/internal/playwright-python/vars.yml
@@ -1,9 +1,4 @@
-base-image: ubuntu-hardened
-base-image-tag: "latest"
 image-repository: playwright-python
-oci-build-params: {}
 src-repo: cloud-gov/playwright-python
 src-target-branch: main
-common-pipelines-trigger: false
-dockerfile-path: []
 dockerfile-trigger: true

--- a/ci/container/internal/pulledpork/vars.yml
+++ b/ci/container/internal/pulledpork/vars.yml
@@ -1,10 +1,3 @@
-base-image: ubuntu-hardened
-base-image-tag: "latest"
 image-repository: pulledpork
-oci-build-params: {
-  DOCKERFILE: src/ci/docker/pulledpork/Dockerfile
-}
+oci-build-params: { DOCKERFILE: src/ci/docker/pulledpork/Dockerfile }
 src-repo: cloud-gov/cg-snort-boshrelease
-common-pipelines-trigger: false
-dockerfile-path: []
-dockerfile-trigger: false

--- a/ci/container/internal/s3-resource/vars.yml
+++ b/ci/container/internal/s3-resource/vars.yml
@@ -1,10 +1,3 @@
-base-image: ubuntu-hardened
-base-image-tag: "latest"
 image-repository: s3-resource
-oci-build-params: {
-  DOCKERFILE: src/Dockerfile
-}
+oci-build-params: { DOCKERFILE: src/Dockerfile }
 src-repo: cloud-gov/s3-resource
-common-pipelines-trigger: false
-dockerfile-path: []
-dockerfile-trigger: false

--- a/ci/container/internal/s3-simple-resource/vars.yml
+++ b/ci/container/internal/s3-simple-resource/vars.yml
@@ -1,8 +1,2 @@
-base-image: ubuntu-hardened
-base-image-tag: "latest"
 image-repository: s3-simple-resource
-oci-build-params: {}
 src-repo: cloud-gov/s3-simple-resource
-common-pipelines-trigger: false
-dockerfile-path: []
-dockerfile-trigger: false

--- a/ci/container/internal/slack-notification-resource/vars.yml
+++ b/ci/container/internal/slack-notification-resource/vars.yml
@@ -1,10 +1,3 @@
-base-image: ubuntu-hardened
-base-image-tag: "latest"
 image-repository: slack-notification-resource
-oci-build-params: {
-  DOCKERFILE: src/dockerfiles/ubuntu/Dockerfile
-}
+oci-build-params: { DOCKERFILE: src/dockerfiles/ubuntu/Dockerfile }
 src-repo: cloud-gov/slack-notification-resource
-common-pipelines-trigger: false
-dockerfile-path: []
-dockerfile-trigger: false

--- a/ci/container/internal/ubuntu-hardened/vars.yml
+++ b/ci/container/internal/ubuntu-hardened/vars.yml
@@ -1,8 +1,4 @@
 base-image: ubuntu
 base-image-tag: "22.04"
 image-repository: ubuntu-hardened
-oci-build-params: {}
 src-repo: cloud-gov/ubuntu-hardened
-common-pipelines-trigger: false
-dockerfile-path: []
-dockerfile-trigger: false

--- a/ci/container/pipeline.yml
+++ b/ci/container/pipeline.yml
@@ -39,6 +39,8 @@ jobs:
           - set_pipeline: ((.:name))
             file: src/container/pipeline-internal.yml
             var_files:
+              # Later values override earlier ones.
+              - src/ci/container/internal/base_vars.yml
               - src/ci/container/internal/((.:name))/vars.yml
 
   - name: set-external-pipelines


### PR DESCRIPTION
## Changes proposed in this pull request:

- 6 of the 8 required variables for pipelines almost always have the same values. This PR extracts them out to a vars file that gets referenced before the pipeline-specific one. Values in the pipeline-specific file override those in the base file.
- Start with internal pipelines only; I'll do external in a follow-up PR
- See https://concourse-ci.org/set-pipeline-step.html#set-pipeline-step

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.