### PR TITLE
Extract default variables to separate file in external pipelines

### DIFF
--- a/ci/container/external/base_vars.yml
+++ b/ci/container/external/base_vars.yml
@@ -1,0 +1,6 @@
+base-image: ubuntu-hardened
+base-image-tag: latest
+oci-build-params: {}
+common-pipelines-trigger: false
+dockerfile-path: []
+dockerfile-trigger: false

--- a/ci/container/external/bosh-io-release-resource/vars.yml
+++ b/ci/container/external/bosh-io-release-resource/vars.yml
@@ -1,11 +1,5 @@
-base-image: ubuntu-hardened
-base-image-tag: "latest"
 image-repository: bosh-io-release-resource
-oci-build-params: {}
 src-source:
   uri: https://github.com/concourse/bosh-io-release-resource
   branch: master
   # Since src is a repo outside the cloud-gov org, don't verify commits.
-common-pipelines-trigger: false
-dockerfile-path: []
-dockerfile-trigger: false

--- a/ci/container/external/bosh-io-stemcell-resource/vars.yml
+++ b/ci/container/external/bosh-io-stemcell-resource/vars.yml
@@ -1,11 +1,5 @@
-base-image: ubuntu-hardened
-base-image-tag: "latest"
 image-repository: bosh-io-stemcell-resource
-oci-build-params: {}
 src-source:
   uri: https://github.com/concourse/bosh-io-stemcell-resource
   branch: master
   # Since src is a repo outside the cloud-gov org, don't verify commits.
-common-pipelines-trigger: false
-dockerfile-path: []
-dockerfile-trigger: false

--- a/ci/container/external/cf-cli-resource/vars.yml
+++ b/ci/container/external/cf-cli-resource/vars.yml
@@ -1,5 +1,3 @@
-base-image: ubuntu-hardened
-base-image-tag: "latest"
 image-repository: cf-cli-resource
 oci-build-params:
   DOCKERFILE: common-dockerfiles/container/dockerfiles/cf-cli-resource/Dockerfile
@@ -7,6 +5,5 @@ src-source:
   uri: https://github.com/nulldriver/cf-cli-resource
   branch: main
   # Since src is a repo outside the cloud-gov org, don't verify commits.
-common-pipelines-trigger: false
 dockerfile-path: ["container/dockerfiles/cf-cli-resource/Dockerfile"]
 dockerfile-trigger: true

--- a/ci/container/external/cloud-service-broker/vars.yml
+++ b/ci/container/external/cloud-service-broker/vars.yml
@@ -1,5 +1,3 @@
-base-image: ubuntu-hardened
-base-image-tag: "latest"
 image-repository: cloud-service-broker
 oci-build-params:
   DOCKERFILE: common-dockerfiles/container/dockerfiles/cloud-service-broker/Dockerfile
@@ -9,6 +7,5 @@ src-source:
   # Modified to start with `^v?` instead of `^`.
   tag_regex: ^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
   # Since src is a repo outside the cloud-gov org, don't verify commits.
-common-pipelines-trigger: false
 dockerfile-path: ["container/dockerfiles/cloud-service-broker/Dockerfile"]
 dockerfile-trigger: true

--- a/ci/container/external/email-resource/vars.yml
+++ b/ci/container/external/email-resource/vars.yml
@@ -1,5 +1,3 @@
-base-image: ubuntu-hardened
-base-image-tag: "latest"
 image-repository: email-resource
 oci-build-params:
   DOCKERFILE: common-dockerfiles/container/dockerfiles/email-resource/Dockerfile
@@ -7,6 +5,5 @@ src-source:
   uri: https://github.com/pivotal-cf/email-resource
   branch: master
   # Since src is a repo outside the cloud-gov org, don't verify commits.
-common-pipelines-trigger: false
 dockerfile-path: ["container/dockerfiles/email-resource/Dockerfile"]
 dockerfile-trigger: true

--- a/ci/container/external/git-resource/vars.yml
+++ b/ci/container/external/git-resource/vars.yml
@@ -1,5 +1,3 @@
-base-image: ubuntu-hardened
-base-image-tag: "latest"
 image-repository: git-resource
 oci-build-params:
   DOCKERFILE: common-dockerfiles/container/dockerfiles/git-resource/Dockerfile
@@ -7,6 +5,5 @@ src-source:
   uri: https://github.com/concourse/git-resource
   branch: master
   # Since src is a repo outside the cloud-gov org, don't verify commits.
-common-pipelines-trigger: false
 dockerfile-path: ["container/dockerfiles/git-resource/Dockerfile"]
 dockerfile-trigger: true

--- a/ci/container/external/openresty/vars.yml
+++ b/ci/container/external/openresty/vars.yml
@@ -1,5 +1,3 @@
-base-image: ubuntu-hardened
-base-image-tag: "latest"
 image-repository: openresty
 oci-build-params:
   DOCKERFILE: common-dockerfiles/container/dockerfiles/openresty/Dockerfile
@@ -7,6 +5,5 @@ src-source:
   uri: https://github.com/openresty/docker-openresty
   branch: master
   # Since src is a repo outside the cloud-gov org, don't verify commits.
-common-pipelines-trigger: false
 dockerfile-path: ["container/dockerfiles/openresty/Dockerfile"]
 dockerfile-trigger: true

--- a/ci/container/external/pool-resource/vars.yml
+++ b/ci/container/external/pool-resource/vars.yml
@@ -1,11 +1,5 @@
-base-image: ubuntu-hardened
-base-image-tag: "latest"
 image-repository: pool-resource
-oci-build-params: {}
 src-source:
   uri: https://github.com/concourse/pool-resource
   branch: master
   # Since src is a repo outside the cloud-gov org, don't verify commits.
-common-pipelines-trigger: false
-dockerfile-path: []
-dockerfile-trigger: false

--- a/ci/container/external/registry-image-resource/vars.yml
+++ b/ci/container/external/registry-image-resource/vars.yml
@@ -1,11 +1,5 @@
-base-image: ubuntu-hardened
-base-image-tag: "latest"
 image-repository: registry-image-resource
-oci-build-params: {}
 src-source:
   uri: https://github.com/concourse/registry-image-resource
   branch: master
   # Since src is a repo outside the cloud-gov org, don't verify commits.
-common-pipelines-trigger: false
-dockerfile-path: []
-dockerfile-trigger: false

--- a/ci/container/external/semver-resource/vars.yml
+++ b/ci/container/external/semver-resource/vars.yml
@@ -1,5 +1,3 @@
-base-image: ubuntu-hardened
-base-image-tag: "latest"
 image-repository: semver-resource
 oci-build-params:
   DOCKERFILE: common-dockerfiles/container/dockerfiles/semver-resource/Dockerfile
@@ -7,6 +5,5 @@ src-source:
   uri: https://github.com/alphagov/paas-semver-resource
   branch: gds_main
   # Since src is a repo outside the cloud-gov org, don't verify commits.
-common-pipelines-trigger: false
 dockerfile-path: ["container/dockerfiles/semver-resource/Dockerfile"]
 dockerfile-trigger: true

--- a/ci/container/external/time-resource/vars.yml
+++ b/ci/container/external/time-resource/vars.yml
@@ -1,11 +1,5 @@
-base-image: ubuntu-hardened
-base-image-tag: "latest"
 image-repository: time-resource
-oci-build-params: {}
 src-source:
   uri: https://github.com/concourse/time-resource
   branch: master
   # Since src is a repo outside the cloud-gov org, don't verify commits.
-common-pipelines-trigger: false
-dockerfile-path: []
-dockerfile-trigger: false

--- a/ci/container/pipeline.yml
+++ b/ci/container/pipeline.yml
@@ -72,7 +72,7 @@ jobs:
               # Contrary to Concourse docs, earlier values override later ones.
               # See https://github.com/concourse/concourse/issues/5455
               - src/ci/container/external/((.:name))/vars.yml
-              - src/ci/container/internal/base_vars.yml
+              - src/ci/container/external/base_vars.yml
 
   - name: set-pages-pipelines
     plan:

--- a/ci/container/pipeline.yml
+++ b/ci/container/pipeline.yml
@@ -69,7 +69,10 @@ jobs:
           - set_pipeline: ((.:name))
             file: src/container/pipeline-external.yml
             var_files:
+              # Contrary to Concourse docs, earlier values override later ones.
+              # See https://github.com/concourse/concourse/issues/5455
               - src/ci/container/external/((.:name))/vars.yml
+              - src/ci/container/internal/base_vars.yml
 
   - name: set-pages-pipelines
     plan:


### PR DESCRIPTION
## Changes proposed in this pull request:

- This is the same change as https://github.com/cloud-gov/common-pipelines/pull/134, but for the external pipelines. One more to follow for Pages.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.