### PR TITLE
Extract default variables to separate file in Pages pipelines

### DIFF
--- a/ci/container/pages/base_vars.yml
+++ b/ci/container/pages/base_vars.yml
@@ -1,0 +1,6 @@
+base-image: ubuntu-hardened
+base-image-tag: latest
+src-target-branch: main
+common-pipelines-trigger: false
+dockerfile-path: []
+dockerfile-trigger: true

--- a/ci/container/pages/dind/vars.yml
+++ b/ci/container/pages/dind/vars.yml
@@ -1,9 +1,3 @@
-base-image: ubuntu-hardened
-base-image-tag: "latest"
 image-repository: pages-dind
 oci-build-params: { CONTEXT: src/dind/v27 }
 src-repo: cloud-gov/pages-images
-src-target-branch: main
-common-pipelines-trigger: false
-dockerfile-path: []
-dockerfile-trigger: true

--- a/ci/container/pages/nginx-v1/vars.yml
+++ b/ci/container/pages/nginx-v1/vars.yml
@@ -1,11 +1,3 @@
-base-image: ubuntu-hardened
-base-image-tag: "latest"
 image-repository: pages-nginx-v1
-oci-build-params: {
-  CONTEXT: src/nginx/v1
-}
+oci-build-params: { CONTEXT: src/nginx/v1 }
 src-repo: cloud-gov/pages-images
-src-target-branch: main
-common-pipelines-trigger: false
-dockerfile-path: []
-dockerfile-trigger: true

--- a/ci/container/pages/node-v20/vars.yml
+++ b/ci/container/pages/node-v20/vars.yml
@@ -1,11 +1,3 @@
-base-image: ubuntu-hardened
-base-image-tag: "latest"
 image-repository: pages-node-v20
-oci-build-params: {
-  CONTEXT: src/node/v20
-}
+oci-build-params: { CONTEXT: src/node/v20 }
 src-repo: cloud-gov/pages-images
-src-target-branch: main
-common-pipelines-trigger: false
-dockerfile-path: []
-dockerfile-trigger: true

--- a/ci/container/pages/postgres-v15/vars.yml
+++ b/ci/container/pages/postgres-v15/vars.yml
@@ -1,11 +1,3 @@
-base-image: ubuntu-hardened
-base-image-tag: "latest"
 image-repository: pages-postgres-v15
-oci-build-params: {
-  CONTEXT: src/postgres/v15
-}
+oci-build-params: { CONTEXT: src/postgres/v15 }
 src-repo: cloud-gov/pages-images
-src-target-branch: main
-common-pipelines-trigger: false
-dockerfile-path: []
-dockerfile-trigger: true

--- a/ci/container/pages/python-v3.11/vars.yml
+++ b/ci/container/pages/python-v3.11/vars.yml
@@ -1,11 +1,3 @@
-base-image: ubuntu-hardened
-base-image-tag: "latest"
 image-repository: pages-python-v3.11
-oci-build-params: {
-  CONTEXT: src/python/v3.11
-}
+oci-build-params: { CONTEXT: src/python/v3.11 }
 src-repo: cloud-gov/pages-images
-src-target-branch: main
-common-pipelines-trigger: false
-dockerfile-path: []
-dockerfile-trigger: true

--- a/ci/container/pages/redis-v7.2/vars.yml
+++ b/ci/container/pages/redis-v7.2/vars.yml
@@ -1,11 +1,3 @@
-base-image: ubuntu-hardened
-base-image-tag: "latest"
-image-repository: pages-redis-v7.2
-oci-build-params: {
-  CONTEXT: src/redis/v7.2
-}
+mage-repository: pages-redis-v7.2
+oci-build-params: { CONTEXT: src/redis/v7.2 }
 src-repo: cloud-gov/pages-images
-src-target-branch: main
-common-pipelines-trigger: false
-dockerfile-path: []
-dockerfile-trigger: true

--- a/ci/container/pages/zap/vars.yml
+++ b/ci/container/pages/zap/vars.yml
@@ -1,9 +1,3 @@
-base-image: ubuntu-hardened
-base-image-tag: "latest"
 image-repository: pages-zap
 oci-build-params: { CONTEXT: src/zap }
 src-repo: cloud-gov/pages-images
-src-target-branch: main
-common-pipelines-trigger: false
-dockerfile-path: []
-dockerfile-trigger: true

--- a/ci/container/pipeline.yml
+++ b/ci/container/pipeline.yml
@@ -92,6 +92,7 @@ jobs:
             team: pages
             var_files:
               - src/ci/container/pages/((.:name))/vars.yml
+              - src/ci/container/pages/base_vars.yml
 
   - name: container-instance-tracking
     plan:


### PR DESCRIPTION
## Changes proposed in this pull request:

- Same change as https://github.com/cloud-gov/common-pipelines/pull/134 and https://github.com/cloud-gov/common-pipelines/pull/137: Simplify creating new pipelines by defaulting common values
- Also format yml with prettier.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.