### PR TITLE
rollback for pages deployment issue

### DIFF
--- a/ci/container/external/registry-image-resource/vars.yml
+++ b/ci/container/external/registry-image-resource/vars.yml
@@ -1,9 +1,9 @@
 image-repository: registry-image-resource
-oci-build-params:
-  DOCKERFILE: common-dockerfiles/container/dockerfiles/registry-image-resource/Dockerfile
+# oci-build-params:
+#   DOCKERFILE: common-dockerfiles/container/dockerfiles/registry-image-resource/Dockerfile
 src-source:
   uri: https://github.com/concourse/registry-image-resource
   branch: master
   # Since src is a repo outside the cloud-gov org, don't verify commits.
-dockerfile-path: ["container/dockerfiles/registry-image-resource/Dockerfile"]
-dockerfile-trigger: true
+# dockerfile-path: ["container/dockerfiles/registry-image-resource/Dockerfile"]
+# dockerfile-trigger: true


### PR DESCRIPTION
## Changes proposed in this pull request:

Rolling back for pages deploy issue: https://ci.fr.cloud.gov/teams/pages/pipelines/cf-build-tasks/jobs/deploy/builds/58?vars.deploy-env=%22dev%22

## Security considerations

Rolling back until the issue can be worked out.
