### PR TITLE
Serialize jobs

### DIFF
--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -1,6 +1,6 @@
 jobs:
   - name: main
-    serial-groups: [container-scans]
+    serial_groups: [container-scans]
     plan:
       - in_parallel:
           - get: src
@@ -66,7 +66,7 @@ jobs:
         icon_url: ((slack-icon-url))
 
   - name: continuous-scan
-    serial-groups: [container-scans]
+    serial_groups: [container-scans]
     plan:
       - in_parallel:
           - get: image
@@ -113,7 +113,7 @@ jobs:
         channel: ((slack-channel-success))
 
   - name: conmon-scan
-    serial-groups: [container-scans]
+    serial_groups: [container-scans]
     plan:
       - in_parallel:
           - get: image

--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -113,6 +113,7 @@ jobs:
         channel: ((slack-channel-success))
 
   - name: conmon-scan
+    serial-groups: [container-scans]
     plan:
       - in_parallel:
           - get: image

--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -1,5 +1,6 @@
 jobs:
   - name: main
+    serial-groups: [container-scans]
     plan:
       - in_parallel:
           - get: src
@@ -65,6 +66,7 @@ jobs:
         icon_url: ((slack-icon-url))
 
   - name: continuous-scan
+    serial-groups: [container-scans]
     plan:
       - in_parallel:
           - get: image

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -127,7 +127,7 @@ jobs:
         icon_url: ((slack-icon-url))
 
   - name: continuous-scan
-    serial-groups: [container-scans]
+    serial_groups: [container-scans]
     plan:
       - in_parallel:
           - get: image
@@ -174,7 +174,7 @@ jobs:
         channel: ((slack-channel-success))
 
   - name: conmon-scan
-    serial-groups: [container-scans]
+    serial_groups: [container-scans]
     plan:
       - in_parallel:
           - get: image

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -61,6 +61,7 @@ jobs:
         status: success
 
   - name: main
+    serial_groups: [container-scans]
     plan:
       - in_parallel:
           - get: src
@@ -126,6 +127,7 @@ jobs:
         icon_url: ((slack-icon-url))
 
   - name: continuous-scan
+    serial-groups: [container-scans]
     plan:
       - in_parallel:
           - get: image

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -174,6 +174,7 @@ jobs:
         channel: ((slack-channel-success))
 
   - name: conmon-scan
+    serial-groups: [container-scans]
     plan:
       - in_parallel:
           - get: image

--- a/container/pipeline-pages.yml
+++ b/container/pipeline-pages.yml
@@ -51,7 +51,7 @@ jobs:
         icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 
   - name: main
-    serial-groups: [container-scans]
+    serial_groups: [container-scans]
     plan:
       - in_parallel:
           - get: src
@@ -117,7 +117,7 @@ jobs:
         icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 
   - name: continuous-scan
-    serial-groups: [container-scans]
+    serial_groups: [container-scans]
     plan:
       - in_parallel:
           - get: image
@@ -167,7 +167,7 @@ jobs:
         icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 
   - name: conmon-scan
-    serial-groups: [container-scans]
+    serial_groups: [container-scans]
     plan:
       - in_parallel:
           - get: image

--- a/container/pipeline-pages.yml
+++ b/container/pipeline-pages.yml
@@ -167,6 +167,7 @@ jobs:
         icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 
   - name: conmon-scan
+    serial-groups: [container-scans]
     plan:
       - in_parallel:
           - get: image

--- a/container/pipeline-pages.yml
+++ b/container/pipeline-pages.yml
@@ -51,6 +51,7 @@ jobs:
         icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 
   - name: main
+    serial-groups: [container-scans]
     plan:
       - in_parallel:
           - get: src
@@ -116,6 +117,7 @@ jobs:
         icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 
   - name: continuous-scan
+    serial-groups: [container-scans]
     plan:
       - in_parallel:
           - get: image


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add `serial_groups` to jobs so that they do not run in parallel, which should help reduce load on concourse

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Reducing load on concourse
