### PR TITLE
Add optional static analysis step to PR job

### DIFF
--- a/ci/container/internal/base_vars.yml
+++ b/ci/container/internal/base_vars.yml
@@ -4,3 +4,8 @@ oci-build-params: {}
 common-pipelines-trigger: false
 dockerfile-path: []
 dockerfile-trigger: false
+static-analysis-cmd: echo
+static-analysis-args:
+  [
+    "No static analysis command configured. Set ((static-analysis-cmd)) and ((static-analysis-args)) in your pipeline configuration file to run static analysis on your source code.",
+  ]

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -24,6 +24,14 @@ jobs:
           path: pull-request
           status: pending
 
+      - task: static-analysis
+        file: common-pipelines/containers/static-analysis.yml
+        input_mapping:
+          src: pull-request
+        vars:
+          cmd: ((static-analysis-cmd))
+          args: ((static-analysis-args))
+
       - task: oci-build
         privileged: true
         file: common-pipelines/container/oci-build.yml

--- a/container/static-analysis.yml
+++ b/container/static-analysis.yml
@@ -1,0 +1,18 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: general-task
+    aws_region: us-gov-west-1
+    tag: latest
+
+inputs:
+  - name: src
+
+run:
+  path: ((cmd))
+  args: ((args))


### PR DESCRIPTION
## Changes proposed in this pull request:

- Authors of Docker images may want to run static analysis tools as part of their PR workflow to ensure quality. This change allows them to configure a command and arguments that can run a static analyzer. 
- Authors can include a script in their repo and run that script, or directly invoke any command available in the `general-task` image. 
- The design could change in the future. For instance, if many images with a given language all configure the same static analyzer, we could instead provide a `static-analysis-language` var, and maintain a script relevant to the language that gets invoked behind the scenes. 
- We could also add more steps like this in the future: For example, `run-tests` step. 
- Related to https://github.com/cloud-gov/product/issues/3112

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

This adds the ability to run user-specified commands in Concourse. The PR job only runs on internal repos, which we control, and the commands must be configured in this repo, which we control. 