### PR TITLE
Fix misspelling in static-analysis step field

### DIFF
--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -25,7 +25,7 @@ jobs:
           status: pending
 
       - task: static-analysis
-        file: common-pipelines/containers/static-analysis.yml
+        file: common-pipelines/container/static-analysis.yml
         input_mapping:
           src: pull-request
         vars:


### PR DESCRIPTION
## Changes proposed in this pull request:

- I forgot it's 'container' singular, not 'containers' plural.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.