### PR TITLE
Attempt to fix variable type mismatch by inlining references to vars

### DIFF
--- a/ci/container/internal/base_vars.yml
+++ b/ci/container/internal/base_vars.yml
@@ -7,5 +7,5 @@ dockerfile-trigger: false
 static-analysis-cmd: echo
 static-analysis-args:
   [
-    "No static analysis command configured. Set ((static-analysis-cmd)) and ((static-analysis-args)) in your pipeline configuration file to run static analysis on your source code.",
+    "No static analysis command configured. Set static-analysis-cmd and static-analysis-args in your pipeline configuration file to run static analysis on your source code.",
   ]

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -28,9 +28,6 @@ jobs:
         file: common-pipelines/container/static-analysis.yml
         input_mapping:
           src: pull-request
-        vars:
-          cmd: ((static-analysis-cmd))
-          args: ((static-analysis-args))
 
       - task: oci-build
         privileged: true

--- a/container/static-analysis.yml
+++ b/container/static-analysis.yml
@@ -14,5 +14,5 @@ inputs:
   - name: src
 
 run:
-  path: ((cmd))
-  args: ((args))
+  path: ((static-analysis-cmd))
+  args: ((static-analysis-args))


### PR DESCRIPTION
## Changes proposed in this pull request:

The current method results in an error:

failed to create task config from bytes common-pipelines/container/static-analysis.yml: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go struct field TaskRunConfig.run.args of type []string

The string in question must be ((args)) inside the task file, but I can verify in the pipeline itself that ((static-analysis-args)) is a []string, so I'm not sure why the slice aspect is getting lost. This attempt may not work, but the nature of our Concourse setup makes it difficult to test by any other method.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.