### PR TITLE
Use trivy to scan the CSB brokerpaks for configuration issues

### DIFF
--- a/ci/container/internal/csb/vars.yml
+++ b/ci/container/internal/csb/vars.yml
@@ -4,3 +4,5 @@ image-repository: csb
 oci-build-params:
   BUILD_ARG_BUILD_ENV: production
 src-repo: cloud-gov/csb
+static-analysis-cmd: trivy
+static-analysis-args: ["config", "src/brokerpaks/*"]


### PR DESCRIPTION
## Changes proposed in this pull request:

- See title. Right now I think a trivy finding will cause the task step to fail, which is desirable. Since this is just a PR, the results don't go anywhere (e.g. Defect Dojo). If we run it on the `main` in the future, they could be uploaded.
- Related to https://github.com/cloud-gov/product/issues/3112

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.