### PR TITLE
Skip downloading Trivy check database, with explanation

### DIFF
--- a/ci/container/internal/csb/vars.yml
+++ b/ci/container/internal/csb/vars.yml
@@ -5,4 +5,9 @@ oci-build-params:
   BUILD_ARG_BUILD_ENV: production
 src-repo: cloud-gov/csb
 static-analysis-cmd: trivy
-static-analysis-args: ["config", "src/brokerpaks/*"]
+# We skip check updates because trivy tries pulling an image from GHCR but
+# often gets rate limited. Trivy has config databases built into the binary
+# and we update it fairly often, whenever we rebuild general-task. Especially
+# since we do not depend on the vulnerability scanning, only the misconfig
+# checks, that is often enough.
+static-analysis-args: ["config", "--skip-check-update", "src/brokerpaks/*"]


### PR DESCRIPTION
## Changes proposed in this pull request:

- Per the comment, we get rate limited trying to pull this image from GHCR. Since it's not being run as a container, I don't think it needs to be hardened, but if we want to use Trivy that way, we should probably mirror it to ECR anyway. Regardless, the checks database is already included, so skip the download for now.
- The better solution is to follow [Trivy's instructions](https://aquasecurity.github.io/trivy/v0.56/docs/advanced/air-gap/) for mirroring the images to our own container registry. I will make a follow-up ticket for this, but I want to get it working as a baseline first.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

We won't get the most up-to-date checks databases. 