### PR TITLE
Fix step failing to stat directory

### DIFF
--- a/ci/container/internal/csb/vars.yml
+++ b/ci/container/internal/csb/vars.yml
@@ -4,10 +4,12 @@ image-repository: csb
 oci-build-params:
   BUILD_ARG_BUILD_ENV: production
 src-repo: cloud-gov/csb
-static-analysis-cmd: trivy
+static-analysis-cmd: sh
 # We skip check updates because trivy tries pulling an image from GHCR but
 # often gets rate limited. Trivy has config databases built into the binary
 # and we update it fairly often, whenever we rebuild general-task. Especially
 # since we do not depend on the vulnerability scanning, only the misconfig
 # checks, that is often enough.
-static-analysis-args: ["config", "--skip-check-update", "src/brokerpaks/*"]
+static-analysis-args:
+  - "-c"
+  - "set -e; trivy config --skip-check-update --exit-code 1 src/brokerpaks/*"


### PR DESCRIPTION
## Changes proposed in this pull request:

- For reasons I couldn't diagnose, the trivy command failed with the previous args because it could not walk the file system. I tested this version of the command by overwriting the pipeline in Concourse and it works. 
- Related to https://github.com/cloud-gov/product/issues/3112

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.