### PR TITLE
Make src branch configurable so images can be built from a topic branch

### DIFF
--- a/ci/container/internal/base_vars.yml
+++ b/ci/container/internal/base_vars.yml
@@ -9,3 +9,4 @@ static-analysis-args:
   [
     "No static analysis command configured. Set static-analysis-cmd and static-analysis-args in your pipeline configuration file to run static analysis on your source code.",
   ]
+src-branch: main

--- a/ci/container/internal/csb/vars.yml
+++ b/ci/container/internal/csb/vars.yml
@@ -4,6 +4,7 @@ image-repository: csb
 oci-build-params:
   BUILD_ARG_BUILD_ENV: production
 src-repo: cloud-gov/csb
+src-branch: brokerpak-topic
 static-analysis-cmd: sh
 # We skip check updates because trivy tries pulling an image from GHCR but
 # often gets rate limited. Trivy has config databases built into the binary

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -291,7 +291,7 @@ resources:
     type: git
     source:
       uri: https://github.com/((src-repo))
-      branch: main
+      branch: ((src-branch))
       commit_verification_keys: ((cloud-gov-pgp-keys))
 
   - name: daily


### PR DESCRIPTION
## Changes proposed in this pull request:

- Today, I build topic branches by manually setting the pipeline, but it gets overwritten periodically. This allows switching the branch more permanently.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Nothing new. Developers can already change this manually from the CLI.