### PR TITLE
Build csb-docproxy image with new builder image feature

### DIFF
--- a/ci/container/internal/base_vars.yml
+++ b/ci/container/internal/base_vars.yml
@@ -1,5 +1,8 @@
 base-image: ubuntu-hardened
 base-image-tag: latest
+# Some Dockerfiles may wish to specify a separate builder image for a multi-stage build. Set these vars to do so. By default, it is the same as base-image to avoid pulling additional layers.
+builder-image: ubuntu-hardened
+builder-image-tag: latest
 oci-build-params: {}
 common-pipelines-trigger: false
 dockerfile-path: []

--- a/ci/container/internal/csb-docproxy/vars.yml
+++ b/ci/container/internal/csb-docproxy/vars.yml
@@ -1,0 +1,5 @@
+builder-image: general-task
+builder-image-tag: latest
+image-repository: csb-docproxy
+src-repo: cloud-gov/csb
+src-branch: brokerpak-topic

--- a/ci/container/pipeline.yml
+++ b/ci/container/pipeline.yml
@@ -36,6 +36,7 @@ jobs:
               - legacy-domain-certificate-renewer-testing
               - opensearch-testing
               - opensearch-dashboards-testing
+              - csb-docproxy
 
         do:
           - set_pipeline: ((.:name))

--- a/container/oci-build.yml
+++ b/container/oci-build.yml
@@ -11,16 +11,17 @@ image_resource:
     tag: latest
 
 caches:
-- path: cache
+  - path: cache
 
 inputs:
-- name: src
-- name: base-image
-- name: common-pipelines
-- name: common-dockerfiles
+  - name: src
+  - name: base-image
+  - name: builder-image
+  - name: common-pipelines
+  - name: common-dockerfiles
 
 outputs:
-- name: image
+  - name: image
 
 run:
   path: build
@@ -38,3 +39,5 @@ params:
   CONTEXT: src
   # Load the base image tarball from the base-image input into an OCI image reference.
   IMAGE_ARG_base_image: base-image/image.tar
+  # Load the builder image in the same manner.
+  IMAGE_ARG_builder_image: builder-image/image.tar

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -247,6 +247,15 @@ resources:
       tag: ((base-image-tag))
       aws_region: us-gov-west-1
 
+  - name: builder-image
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: ((builder-image))
+      tag: ((builder-image-tag))
+      aws_region: us-gov-west-1
+
   - name: common-pipelines
     type: git
     source:


### PR DESCRIPTION
## Changes proposed in this pull request:

- This change adds a new feature to the OCI build step for the internal pipeline: The ability to specify a builder image. Many docker images are built using multi-stage builds: First, a more fully-featured builder image is used to build an application; next, the build artifacts are copied to a smaller final base image. 
- The motivating use case is building a Go application related to the Cloud Service Broker. A builder step with the Go toolchain builds the application, and a final step copies the binary to our standard base image. 
- Further motivation for the builder image here: https://github.com/cloud-gov/product/issues/3216#issuecomment-2536272676
- Related to https://github.com/cloud-gov/product/issues/3216

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Updates our standard container process. Only applies to internal pipelines.