### PR TITLE
Add missing get steps for builder image

### DIFF
--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -6,6 +6,11 @@ jobs:
             version: every
             trigger: true
 
+          - get: builder-image
+            trigger: true
+            params:
+              format: oci
+
           - get: base-image
             trigger: true
             params:
@@ -87,6 +92,11 @@ jobs:
             trigger: true
 
           - get: base-image
+            trigger: true
+            params:
+              format: oci
+
+          - get: builder-image
             trigger: true
             params:
               format: oci


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fix to previous PR, which was missing get steps.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

See previous PR.