### PR TITLE
Fix build errors related to builder image

### DIFF
--- a/ci/container/internal/base_vars.yml
+++ b/ci/container/internal/base_vars.yml
@@ -5,6 +5,7 @@ builder-image: ubuntu-hardened
 builder-image-tag: latest
 oci-build-params: {}
 common-pipelines-trigger: false
+# Defaults to the root of the source repo if unspecified.
 dockerfile-path: []
 dockerfile-trigger: false
 static-analysis-cmd: echo

--- a/ci/container/internal/csb-docproxy/vars.yml
+++ b/ci/container/internal/csb-docproxy/vars.yml
@@ -3,3 +3,4 @@ builder-image-tag: latest
 image-repository: csb-docproxy
 src-repo: cloud-gov/csb
 src-branch: brokerpak-topic
+dockerfile-path: ["docproxy/Dockerfile"]

--- a/container/oci-build.yml
+++ b/container/oci-build.yml
@@ -17,6 +17,7 @@ inputs:
   - name: src
   - name: base-image
   - name: builder-image
+    optional: true
   - name: common-pipelines
   - name: common-dockerfiles
 

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -7,7 +7,7 @@ jobs:
             trigger: true
 
           - get: builder-image
-            trigger: true
+            trigger: false
             params:
               format: oci
 
@@ -97,7 +97,7 @@ jobs:
               format: oci
 
           - get: builder-image
-            trigger: true
+            trigger: false
             params:
               format: oci
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- The change in https://github.com/cloud-gov/common-pipelines/pull/151 broke external pipelines due to missing input.
- The csb-dockerproxy was also broken due to the Dockerfile being located in a subfolder.
- This change also reduces rebuilds of images. 

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.