### PR TITLE
Use CONTEXT instead of DOCKERFILE to build from correct working dir

### DIFF
--- a/ci/container/internal/csb-docproxy/vars.yml
+++ b/ci/container/internal/csb-docproxy/vars.yml
@@ -2,4 +2,4 @@ image-repository: csb-docproxy
 src-repo: cloud-gov/csb
 src-branch: brokerpak-topic
 oci-build-params:
-  DOCKERFILE: "src/docproxy/Dockerfile"
+  CONTEXT: "src/docproxy"


### PR DESCRIPTION
## Changes proposed in this pull request:

- Without this, the oci build step tries copying files from the repo root instead of the `docproxy/` directory.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.