### PR TITLE
remove get of the general-task resource

### DIFF
--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -17,8 +17,6 @@ jobs:
           - get: common-dockerfiles
             trigger: ((dockerfile-trigger))
 
-          - get: general-task
-
       - task: oci-build
         privileged: true
         file: common-pipelines/container/oci-build.yml
@@ -80,8 +78,6 @@ jobs:
           - get: daily
             trigger: true
 
-          - get: general-task
-
       - in_parallel:
           - do:
               - task: scan-image
@@ -126,8 +122,6 @@ jobs:
 
           - get: monthly
             trigger: true
-
-          - get: general-task
 
           - get: conmon-scan-file
 
@@ -212,15 +206,6 @@ resources:
     source:
       expression: "0 6 22 * *"
       location: "America/New_York"
-
-  - name: general-task
-    type: registry-image
-    source:
-      aws_access_key_id: ((ecr_aws_key))
-      aws_secret_access_key: ((ecr_aws_secret))
-      repository: general-task
-      aws_region: us-gov-west-1
-      tag: latest
 
   - name: conmon-scan-file
     type: s3-iam

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -17,8 +17,6 @@ jobs:
           - get: common-dockerfiles
             trigger: ((dockerfile-trigger))
 
-          - get: general-task
-
       - put: pull-request
         params:
           path: pull-request
@@ -97,8 +95,6 @@ jobs:
           - get: common-dockerfiles
             trigger: ((dockerfile-trigger))
 
-          - get: general-task
-
       - task: oci-build
         privileged: true
         file: common-pipelines/container/oci-build.yml
@@ -160,8 +156,6 @@ jobs:
           - get: daily
             trigger: true
 
-          - get: general-task
-
       - in_parallel:
           - do:
               - task: scan-image
@@ -206,8 +200,6 @@ jobs:
 
           - get: monthly
             trigger: true
-
-          - get: general-task
 
           - get: conmon-scan-file
 
@@ -304,15 +296,6 @@ resources:
     source:
       expression: "0 6 22 * *"
       location: "America/New_York"
-
-  - name: general-task
-    type: registry-image
-    source:
-      aws_access_key_id: ((ecr_aws_key))
-      aws_secret_access_key: ((ecr_aws_secret))
-      repository: general-task
-      aws_region: us-gov-west-1
-      tag: latest
 
   - name: conmon-scan-file
     type: s3-iam

--- a/container/pipeline-pages.yml
+++ b/container/pipeline-pages.yml
@@ -17,8 +17,6 @@ jobs:
           - get: common-dockerfiles
             trigger: ((dockerfile-trigger))
 
-          - get: general-task
-
       - task: oci-build
         privileged: true
         file: common-pipelines/container/oci-build.yml
@@ -67,8 +65,6 @@ jobs:
 
           - get: common-dockerfiles
             trigger: ((dockerfile-trigger))
-
-          - get: general-task
 
       - task: oci-build
         privileged: true
@@ -131,8 +127,6 @@ jobs:
           - get: daily
             trigger: true
 
-          - get: general-task
-
       - in_parallel:
           - do:
               - task: scan-image
@@ -180,8 +174,6 @@ jobs:
 
           - get: monthly
             trigger: true
-
-          - get: general-task
 
           - get: conmon-scan-file
 
@@ -278,15 +270,6 @@ resources:
     source:
       expression: "0 6 22 * *"
       location: "America/New_York"
-
-  - name: general-task
-    type: registry-image
-    source:
-      aws_access_key_id: ((ecr_aws_key))
-      aws_secret_access_key: ((ecr_aws_secret))
-      repository: general-task
-      aws_region: us-gov-west-1
-      tag: latest
 
   - name: conmon-scan-file
     type: s3-iam


### PR DESCRIPTION
## Changes proposed in this pull request:

- Removing the `get: general-task` steps from the pipelines as it is not necessary to get the general-task resource for the subsequent tasks
- Removing the `general-task` resource since we will no longer have any get steps that require it

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Removing unneeded code to improve performance
