### PR TITLE
Add code scanning

### DIFF
--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -1,10 +1,32 @@
 jobs:
+  - name: code-scan
+    plan:
+      - get: src
+        trigger: true
+      - task: scan
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              aws_access_key_id: ((ecr_aws_key))
+              aws_secret_access_key: ((ecr_aws_secret))
+              repository: general-task
+              aws_region: us-gov-west-1
+              tag: latest
+          run:
+            path: sh
+            args:
+              - "-c"
+              - "set -e; trivy repo --scanners vuln,misconfig,secret https://github.com/((src-repo))"
+
   - name: main
     serial_groups: [container-scans]
     plan:
       - in_parallel:
           - get: src
             trigger: true
+            passed: [code-scan]
 
           - get: base-image
             trigger: true

--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -18,7 +18,7 @@ jobs:
             path: sh
             args:
               - "-c"
-              - "set -e; trivy repo --scanners vuln,misconfig,secret https://github.com/((src-repo))"
+              - "set -e; trivy repo --scanners vuln,misconfig,secret ((src-source.uri))"
 
   - name: main
     serial_groups: [container-scans]

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -1,10 +1,33 @@
 jobs:
+  - name: code-scan
+    plan:
+      - get: pull-request
+        version: every
+        trigger: true
+      - task: scan
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              aws_access_key_id: ((ecr_aws_key))
+              aws_secret_access_key: ((ecr_aws_secret))
+              repository: general-task
+              aws_region: us-gov-west-1
+              tag: latest
+          run:
+            path: sh
+            args:
+              - "-c"
+              - "set -e; trivy repo --scanners vuln,misconfig,secret https://github.com/((src-repo))"
+
   - name: pull-request
     plan:
       - in_parallel:
           - get: pull-request
             version: every
             trigger: true
+            passed: [code-scan]
 
           - get: base-image
             trigger: true

--- a/container/pipeline-pages.yml
+++ b/container/pipeline-pages.yml
@@ -1,10 +1,33 @@
 jobs:
+  - name: code-scan
+    plan:
+      - get: pull-request
+        version: every
+        trigger: true
+      - task: scan
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              aws_access_key_id: ((ecr_aws_key))
+              aws_secret_access_key: ((ecr_aws_secret))
+              repository: general-task
+              aws_region: us-gov-west-1
+              tag: latest
+          run:
+            path: sh
+            args:
+              - "-c"
+              - "set -e; trivy repo --scanners vuln,misconfig,secret https://github.com/((src-repo))"
+
   - name: pull-request
     plan:
       - in_parallel:
           - get: src
             resource: pull-request
             trigger: true
+            passed: [code-scan]
 
           - get: base-image
             trigger: true


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds a job to scan the source code (for vulnerabilities, misconfigurations, and secrets) that will be used to build the container image before running any other job

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Improving security by scanning the code we pull in
