### PR TITLE
Cut a few seconds from pipeline by entirely skipping image get after put

### DIFF
--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -73,8 +73,7 @@ jobs:
         inputs:
           - image
           - src
-        get_params:
-          skip_download: true
+        no_get: true
         params:
           image: image/image.tar
           additional_tags: src/.git/short_ref

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -156,8 +156,7 @@ jobs:
         inputs:
           - image
           - src
-        get_params:
-          skip_download: true
+        no_get: true
         params:
           image: image/image.tar
           additional_tags: src/.git/short_ref

--- a/container/pipeline-pages.yml
+++ b/container/pipeline-pages.yml
@@ -127,8 +127,7 @@ jobs:
         inputs:
           - image
           - src
-        get_params:
-          skip_download: true
+        no_get: true
         params:
           image: image/image.tar
           additional_tags: src/.git/short_ref


### PR DESCRIPTION
## Changes proposed in this pull request:

The previous behavior skips downloading the image after uploading it to ECR, but still takes some time - up to 25 seconds, based on a quick review of one pipeline - to execute the noop get. This change entirely removes the get, which is not necessary since the image is not used after the put step.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.