### PR TITLE
Export usg audit results

### DIFF
--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -39,6 +39,10 @@ jobs:
           - get: common-dockerfiles
             trigger: ((dockerfile-trigger))
 
+          - get: audit-html-file
+
+          - get: audit-xml-file
+
       - task: oci-build
         privileged: true
         file: common-pipelines/container/oci-build.yml
@@ -52,6 +56,8 @@ jobs:
           - task: usg-audit
             file: common-pipelines/container/usg-audit.yml
             image: image
+            params:
+              IMAGENAME: ((image-repository))
 
           - do:
               - task: scan-image
@@ -68,6 +74,14 @@ jobs:
               - task: software-inventory
                 file: common-pipelines/container/software-inventory.yml
                 image: image
+
+      - put: audit-xml-file
+        params:
+          file: audit/((image-repository))-audit.xml
+
+      - put: audit-html-file
+        params:
+          file: audit/((image-repository))-audit.html
 
       - put: image
         inputs:
@@ -240,6 +254,24 @@ resources:
       region_name: us-gov-west-1
       server_side_encryption: AES256
       initial_version: conmon-scan/((image-repository)).xml
+
+  - name: audit-html-file
+    type: s3-iam
+    source:
+      bucket: ((container_scans_bucket))
+      versioned_file: audit/((image-repository))-audit.html
+      region_name: us-gov-west-1
+      server_side_encryption: AES256
+      initial_version: audit/((image-repository))-audit.html
+
+  - name: audit-xml-file
+    type: s3-iam
+    source:
+      bucket: ((container_scans_bucket))
+      versioned_file: audit/((image-repository))-audit.xml
+      region_name: us-gov-west-1
+      server_side_encryption: AES256
+      initial_version: audit/((image-repository))-audit.xml
 
 resource_types:
   - name: registry-image

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -140,14 +140,6 @@ jobs:
             file: common-pipelines/container/usg-audit.yml
             image: image
 
-          - put: audit-xml-file
-            params:
-              file: audit/((image-repository))-audit.xml
-
-          - put: audit-html-file
-            params:
-              file: audit/((image-repository))-audit.html
-
           - do:
               - task: scan-image
                 file: common-pipelines/container/scan-image.yml
@@ -163,6 +155,14 @@ jobs:
               - task: software-inventory
                 file: common-pipelines/container/software-inventory.yml
                 image: image
+
+      - put: audit-xml-file
+        params:
+          file: audit/((image-repository))-audit.xml
+
+      - put: audit-html-file
+        params:
+          file: audit/((image-repository))-audit.html
 
       - put: image
         inputs:

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -122,6 +122,10 @@ jobs:
           - get: common-dockerfiles
             trigger: ((dockerfile-trigger))
 
+          - get: audit-html-file
+
+          - get: audit-xml-file
+
       - task: oci-build
         privileged: true
         file: common-pipelines/container/oci-build.yml
@@ -135,6 +139,14 @@ jobs:
           - task: usg-audit
             file: common-pipelines/container/usg-audit.yml
             image: image
+
+          - put: audit-xml-file
+            params:
+              file: audit/((image-repository))-audit.xml
+
+          - put: audit-html-file
+            params:
+              file: audit/((image-repository))-audit.html
 
           - do:
               - task: scan-image
@@ -335,6 +347,24 @@ resources:
       region_name: us-gov-west-1
       server_side_encryption: AES256
       initial_version: conmon-scan/((image-repository)).xml
+
+  - name: audit-html-file
+    type: s3-iam
+    source:
+      bucket: ((container_scans_bucket))
+      versioned_file: audit/((image-repository))-audit.html
+      region_name: us-gov-west-1
+      server_side_encryption: AES256
+      initial_version: audit/((image-repository))-audit.html
+
+  - name: audit-xml-file
+    type: s3-iam
+    source:
+      bucket: ((container_scans_bucket))
+      versioned_file: audit/((image-repository))-audit.xml
+      region_name: us-gov-west-1
+      server_side_encryption: AES256
+      initial_version: audit/((image-repository))-audit.xml
 
 resource_types:
   - name: registry-image

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -139,6 +139,8 @@ jobs:
           - task: usg-audit
             file: common-pipelines/container/usg-audit.yml
             image: image
+            params:
+              IMAGENAME: ((image-repository))
 
           - do:
               - task: scan-image

--- a/container/pipeline-pages.yml
+++ b/container/pipeline-pages.yml
@@ -93,6 +93,10 @@ jobs:
           - get: common-dockerfiles
             trigger: ((dockerfile-trigger))
 
+          - get: audit-html-file
+
+          - get: audit-xml-file
+
       - task: oci-build
         privileged: true
         file: common-pipelines/container/oci-build.yml
@@ -106,6 +110,8 @@ jobs:
           - task: usg-audit
             file: common-pipelines/container/usg-audit.yml
             image: image
+            params:
+              IMAGENAME: ((image-repository))
 
           - do:
               - task: scan-image
@@ -122,6 +128,14 @@ jobs:
               - task: software-inventory
                 file: common-pipelines/container/software-inventory.yml
                 image: image
+
+      - put: audit-xml-file
+        params:
+          file: audit/((image-repository))-audit.xml
+
+      - put: audit-html-file
+        params:
+          file: audit/((image-repository))-audit.html
 
       - put: image
         inputs:
@@ -309,6 +323,24 @@ resources:
       region_name: us-gov-west-1
       server_side_encryption: AES256
       initial_version: conmon-scan/((image-repository)).xml
+
+  - name: audit-html-file
+    type: s3-iam
+    source:
+      bucket: ((container_scans_bucket))
+      versioned_file: audit/((image-repository))-audit.html
+      region_name: us-gov-west-1
+      server_side_encryption: AES256
+      initial_version: audit/((image-repository))-audit.html
+
+  - name: audit-xml-file
+    type: s3-iam
+    source:
+      bucket: ((container_scans_bucket))
+      versioned_file: audit/((image-repository))-audit.xml
+      region_name: us-gov-west-1
+      server_side_encryption: AES256
+      initial_version: audit/((image-repository))-audit.xml
 
 resource_types:
   - name: pull-request

--- a/container/usg-audit.sh
+++ b/container/usg-audit.sh
@@ -31,10 +31,10 @@ python3 -m pip install beautifulsoup4
 
 # Run cis audit and put html results into cis-audit.html file
 echo "running audit"
-usg audit --tailoring-file common-pipelines/container/tailor.xml --html-file $PWD/audit/cis-audit.html --results-file $PWD/audit/cis-audit.xml
+usg audit --tailoring-file common-pipelines/container/tailor.xml --html-file /audit/$IMAGENAME-audit.html --results-file /audit/$IMAGENAME-audit.xml
 
 # Parse the resulting cis-audit.html file looking for pass/fail via a python script
-if [ "$(./common-pipelines/container/parse_cis_audit_html.py --inputfile audit/cis-audit.html)" == "failed" ]
+if [ "$(./common-pipelines/container/parse_cis_audit_html.py --inputfile audit/$IMAGENAME-audit.html)" == "failed" ]
 then
   echo "Container hardening audit FAILED"
   exit 1

--- a/container/usg-audit.sh
+++ b/container/usg-audit.sh
@@ -2,8 +2,8 @@
 set -eo pipefail
 
 # set up dir and file
-touch audit/cis-audit.html
-touch audit/cis-audit.xml
+touch audit/$IMAGENAME-audit.html
+touch audit/$IMAGENAME-audit.xml
 
 echo "Configuring ua attach config"
 cat <<EOF >> ua-attach-config.yaml

--- a/container/usg-audit.sh
+++ b/container/usg-audit.sh
@@ -31,7 +31,7 @@ python3 -m pip install beautifulsoup4
 
 # Run cis audit and put html results into cis-audit.html file
 echo "running audit"
-usg audit --tailoring-file common-pipelines/container/tailor.xml --html-file /audit/$IMAGENAME-audit.html --results-file /audit/$IMAGENAME-audit.xml
+usg audit --tailoring-file common-pipelines/container/tailor.xml --html-file $PWD/audit/$IMAGENAME-audit.html --results-file $PWD/audit/$IMAGENAME-audit.xml
 
 # Parse the resulting cis-audit.html file looking for pass/fail via a python script
 if [ "$(./common-pipelines/container/parse_cis_audit_html.py --inputfile audit/$IMAGENAME-audit.html)" == "failed" ]

--- a/container/usg-audit.yml
+++ b/container/usg-audit.yml
@@ -3,7 +3,6 @@ platform: linux
 
 inputs:
   - name: common-pipelines
-  - name: image
 
 outputs:
   - name: audit

--- a/container/usg-audit.yml
+++ b/container/usg-audit.yml
@@ -2,10 +2,11 @@
 platform: linux
 
 inputs:
-- name: common-pipelines
+  - name: common-pipelines
+  - name: image
 
 outputs:
-- name: audit
+  - name: audit
 
 run:
   path: common-pipelines/container/usg-audit.sh


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds a task to upload the usg audit files to S3 whenever an image is built

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

This helps to meet compliance requirements about storing benchmark scan results
