### PR TITLE
updating cf cli versions

### DIFF
--- a/container/dockerfiles/cf-cli-resource/Dockerfile
+++ b/container/dockerfiles/cf-cli-resource/Dockerfile
@@ -22,13 +22,13 @@ RUN mkdir -p /opt/cf-cli-${CF_CLI_6_VERSION} \
   | tar -zxC /opt/cf-cli-${CF_CLI_6_VERSION} \
   && ln -s /opt/cf-cli-${CF_CLI_6_VERSION}/cf /usr/local/bin
 
-ARG CF_CLI_7_VERSION=7.7.12
+ARG CF_CLI_7_VERSION=7.8.0
 RUN mkdir -p /opt/cf-cli-${CF_CLI_7_VERSION} \
   && curl -SL "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_7_VERSION}" \
   | tar -zxC /opt/cf-cli-${CF_CLI_7_VERSION} \
   && ln -s /opt/cf-cli-${CF_CLI_7_VERSION}/cf7 /usr/local/bin
 
-ARG CF_CLI_8_VERSION=8.8.0
+ARG CF_CLI_8_VERSION=8.11.0
 RUN mkdir -p /opt/cf-cli-${CF_CLI_8_VERSION} \
   && curl -SL "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_8_VERSION}" \
   | tar -zxC /opt/cf-cli-${CF_CLI_8_VERSION} \


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updates cf cli v7 and v8 for the cf-cli-resource

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Updating cf cli versions for the cf-cli-resource image
