### PR TITLE
Fix jq error in bosh-io-resource/move to local Dockerfile from upstream

### DIFF
--- a/ci/container/external/bosh-io-release-resource/vars.yml
+++ b/ci/container/external/bosh-io-release-resource/vars.yml
@@ -3,3 +3,5 @@ src-source:
   uri: https://github.com/concourse/bosh-io-release-resource
   branch: master
   # Since src is a repo outside the cloud-gov org, don't verify commits.
+dockerfile-path: ["container/dockerfiles/bosh-io-release-resource/Dockerfile"]
+dockerfile-trigger: true

--- a/container/dockerfiles/bosh-io-release-resource/dockerfile
+++ b/container/dockerfiles/bosh-io-release-resource/dockerfile
@@ -1,0 +1,35 @@
+ARG base_image
+ARG builder_image=paketobuildpacks/build-jammy-base
+
+FROM ${builder_image} AS tests
+USER root
+RUN apt update && apt upgrade -y -o Dpkg::Options::="--force-confdef"
+RUN apt update && apt install -y --no-install-recommends \
+  wget \
+  curl \
+  ca-certificates \
+  jq \
+  ruby-full \
+  && rm -rf /var/lib/apt/lists/*
+ADD assets/ /opt/resource/
+RUN wget "https://github.com/moparisthebest/static-curl/releases/download/v8.11.0/curl-amd64" -O /opt/resource/curl
+RUN chmod +x /opt/resource/*
+ADD . /resource
+WORKDIR /resource
+RUN gem install bundler -v 2.1.4
+RUN bundle install --local && bundle exec rspec
+
+FROM ${base_image} AS resource
+USER root
+
+COPY --from=busybox:uclibc /bin/mktemp /bin/
+COPY --from=busybox:uclibc /bin/mkdir /bin/
+COPY --from=busybox:uclibc /bin/sha256sum /bin/
+COPY --from=busybox:uclibc /bin/sha1sum /bin/
+#COPY --from=stedolan/jq /usr/local/bin/jq /bin/
+COPY --from=tests /opt/resource/curl /bin/
+
+ADD assets/ /opt/resource/
+RUN chmod +x /opt/resource/*
+
+FROM resource

--- a/container/dockerfiles/bosh-io-release-resource/dockerfile
+++ b/container/dockerfiles/bosh-io-release-resource/dockerfile
@@ -14,6 +14,7 @@ RUN apt update && apt install -y --no-install-recommends \
 ADD assets/ /opt/resource/
 RUN wget "https://github.com/moparisthebest/static-curl/releases/download/v8.11.0/curl-amd64" -O /opt/resource/curl
 RUN chmod +x /opt/resource/*
+RUN wget  "https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64" -O /opt/resource/jq
 ADD . /resource
 WORKDIR /resource
 RUN gem install bundler -v 2.1.4
@@ -28,6 +29,7 @@ COPY --from=busybox:uclibc /bin/sha256sum /bin/
 COPY --from=busybox:uclibc /bin/sha1sum /bin/
 #COPY --from=stedolan/jq /usr/local/bin/jq /bin/
 COPY --from=tests /opt/resource/curl /bin/
+COPY --from=tests /opt/resource/jq /bin/
 
 ADD assets/ /opt/resource/
 RUN chmod +x /opt/resource/*

--- a/container/dockerfiles/bosh-io-release-resource/dockerfile
+++ b/container/dockerfiles/bosh-io-release-resource/dockerfile
@@ -13,8 +13,8 @@ RUN apt update && apt install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 ADD assets/ /opt/resource/
 RUN wget "https://github.com/moparisthebest/static-curl/releases/download/v8.11.0/curl-amd64" -O /opt/resource/curl
-RUN chmod +x /opt/resource/*
 RUN wget  "https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64" -O /opt/resource/jq
+RUN chmod +x /opt/resource/*
 ADD . /resource
 WORKDIR /resource
 RUN gem install bundler -v 2.1.4


### PR DESCRIPTION
## Changes proposed in this pull request:

- Move to use local/in-repo dockerfile for bosh-io-resource
- Pulling latest binary from GH instead of 9 year old Docker image based on v1 schema

## Notes

- I will also make a PR to upstream so if we want to revert back to upstream once PR merged we can

## Security considerations

Running latest versions of code reduces risks
