### PR TITLE
update audit to use disa stig tailoring file

### DIFF
--- a/container/parse_stig_audit_html.py
+++ b/container/parse_stig_audit_html.py
@@ -7,7 +7,7 @@ Search for failed scan results to determine if an image can
 be promoted from staging to production
 """
 # This is a script to parse the output of
-# the usg audit in html from cis-audit.html
+# the usg audit in html from stig-audit.html
 
 
 def main():
@@ -29,7 +29,7 @@ def main():
 def get_args():
     """Parse the arguments looking for just one, inputfile"""
     parser = argparse.ArgumentParser(description=__DESCRIPTION__)
-    parser.add_argument('--inputfile', help="the cis-audit html file>")
+    parser.add_argument('--inputfile', help="the stig-audit html file>")
     return parser.parse_args()
 
 

--- a/container/tailor.xml
+++ b/container/tailor.xml
@@ -1,545 +1,433 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
   <benchmark href="/usr/share/ubuntu-scap-security-guides/1/benchmarks/ssg-ubuntu2204-xccdf.xml"/>
-  <version time="2023-06-07T15:29:53">1</version>
-  <Profile id="xccdf_org.ssgproject.content_profile_cis_level1_server_customized" extends="xccdf_org.ssgproject.content_profile_cis_level1_server">
-    <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 22.04 Level 1 Server Benchmark [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 22.04 LTS Benchmark, v1.0.0, released 08-30-2022.</description>
-    <!--1.1.1.1 Ensure mounting of cramfs filesystems is disabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_kernel_module_cramfs_disabled" selected="true"/>
-    <!--1.1.2.1 Ensure /tmp is a separate partition (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_partition_for_tmp" selected="true"/>
-    <!--1.1.2.2 Ensure nodev option set on /tmp partition (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_mount_option_tmp_nodev" selected="true"/>
-    <!--1.1.2.3 Ensure noexec option set on /tmp partition (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_mount_option_tmp_noexec" selected="true"/>
-    <!--1.1.2.4 Ensure nosuid option set on /tmp partition (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_mount_option_tmp_nosuid" selected="true"/>
-    <!--1.1.3.2 Ensure nodev option set on /var partition (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_mount_option_var_nodev" selected="true"/>
-    <!--1.1.3.3 Ensure nosuid option set on /var partition (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_mount_option_var_nosuid" selected="true"/>
-    <!--1.1.4.2 Ensure noexec option set on /var/tmp partition (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_mount_option_var_tmp_noexec" selected="true"/>
-    <!--1.1.4.3 Ensure nosuid option set on /var/tmp partition (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_mount_option_var_tmp_nosuid" selected="true"/>
-    <!--1.1.4.4 Ensure nodev option set on /var/tmp partition (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_mount_option_var_tmp_nodev" selected="true"/>
-    <!--1.1.5.2 Ensure nodev option set on /var/log partition (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_mount_option_var_log_nodev" selected="true"/>
-    <!--1.1.5.3 Ensure noexec option set on /var/log partition (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_mount_option_var_log_noexec" selected="true"/>
-    <!--1.1.5.4 Ensure nosuid option set on /var/log partition (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_mount_option_var_log_nosuid" selected="true"/>
-    <!--1.1.6.2 Ensure noexec option set on /var/log/audit partition (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_mount_option_var_log_audit_noexec" selected="true"/>
-    <!--1.1.6.3 Ensure nodev option set on /var/log/audit partition (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_mount_option_var_log_audit_nodev" selected="true"/>
-    <!--1.1.6.4 Ensure nosuid option set on /var/log/audit partition (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_mount_option_var_log_audit_nosuid" selected="true"/>
-    <!--1.1.7.2 Ensure nodev option set on /home partition (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_mount_option_home_nodev" selected="true"/>
-    <!--1.1.7.2 Ensure nosuid option set on /home partition (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_mount_option_home_nosuid" selected="true"/>
-    <!--1.1.8.1 Ensure nodev option set on /dev/shm partition (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_mount_option_dev_shm_nodev" selected="true"/>
-    <!--1.1.8.2 Ensure noexec option set on /dev/shm partition (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_mount_option_dev_shm_noexec" selected="true"/>
-    <!--1.1.8.3 Ensure nosuid option set on /dev/shm partition (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_mount_option_dev_shm_nosuid" selected="true"/>
-    <!--1.1.9 Disable Automounting (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_service_autofs_disabled" selected="true"/>
-    <!--1.1.10 Disable USB Storage (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_kernel_module_usb-storage_disabled" selected="true"/>
-    <!--1.3.1 Ensure AIDE is installed (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_aide_installed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_aide_build_database" selected="true"/>
-    <!--1.3.2 Ensure filesystem integrity is regularly checked (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_aide_periodic_cron_checking" selected="true"/>
-    <!--1.4.1 Ensure bootloader password is set (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_grub2_password" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_grub2_uefi_password" selected="true"/>
-    <!--1.4.2 Ensure permissions on bootloader config are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_grub2_cfg" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_grub2_cfg" selected="true"/>
-    <!--1.4.3 Ensure authentication required for single user mode (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_ensure_root_password_configured" selected="false"/>
-    <!--1.5.1 Ensure address space layout randomization (ASLR) is enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_kernel_randomize_va_space" selected="true"/>
-    <!--1.5.2 Ensure prelink is disabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_prelink_removed" selected="true"/>
-    <!--1.5.3 Ensure Automatic Error Reporting is not enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_service_apport_disabled" selected="true"/>
-    <!--1.5.4 Ensure core dumps are restricted (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_disable_users_coredumps" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_fs_suid_dumpable" selected="true"/>
-    <!--1.6.1.1 Ensure AppArmor is installed (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_apparmor_installed" selected="true"/>
-    <!--1.6.1.2 Ensure AppArmor is enabled in the bootloader configuration (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_grub2_enable_apparmor" selected="true"/>
-    <!--1.6.1.3 Ensure all AppArmor Profiles are in enforce or complain mode (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_apparmor_mode">complain</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_all_apparmor_profiles_in_enforce_complain_mode" selected="true"/>
-    <!--1.7.1 Ensure message of the day is configured properly (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_login_banner_text">^Authorized[\s\n]+uses[\s\n]+only\.[\s\n]+All[\s\n]+activity[\s\n]+may[\s\n]+be[\s\n]+monitored[\s\n]+and[\s\n]+reported\.$</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_banner_etc_motd" selected="true"/>
-    <!--1.7.2 Ensure local login warning banner is configured properly (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_banner_etc_issue" selected="true"/>
-    <!--1.7.3 Ensure remote login warning banner is configured properly (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_banner_etc_issue_net" selected="true"/>
-    <!--1.7.4 Ensure permissions on /etc/motd are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_motd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_motd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_motd" selected="true"/>
-    <!--1.7.5 Ensure permissions on /etc/issue are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_issue" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_issue" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_issue" selected="true"/>
-    <!--1.7.6 Ensure permissions on /etc/issue.net are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_issue_net" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_issue_net" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_issue_net" selected="true"/>
-    <!--1.8.2 Ensure GDM login banner is configured (Automated)-->
+  <version time="2025-02-01T13:30:17">1</version>
+  <Profile id="xccdf_org.ssgproject.content_profile_stig_customized" extends="xccdf_org.ssgproject.content_profile_stig">
+    <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">DISA-STIG Benchmark [CUSTOMIZED]</title>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the DISA-STIG v.1, rel.1, released 2024-04-10.</description>
+    <!--UBTU-22-271010 The Ubuntu operating system must enable the graphical user logon banner to display the Standard Mandatory DoD Notice and Consent Banner before granting local access to the system via a graphical user logon.-->
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_banner_enabled" selected="true"/>
+    <!--UBTU-22-271015 The Ubuntu operating system must display the Standard Mandatory DoD Notice and Consent Banner before granting local access to the system via a graphical user logon.-->
+    <set-value idref="xccdf_org.ssgproject.content_value_login_banner_text">^(You[\s\n]+are[\s\n]+accessing[\s\n]+a[\s\n]+U\.S\.[\s\n]+Government[\s\n]+\(USG\)[\s\n]+Information[\s\n]+System[\s\n]+\(IS\)[\s\n]+that[\s\n]+is[\s\n]+provided[\s\n]+for[\s\n]+USG\-authorized[\s\n]+use[\s\n]+only\.[\s\n]+By[\s\n]+using[\s\n]+this[\s\n]+IS[\s\n]+\(which[\s\n]+includes[\s\n]+any[\s\n]+device[\s\n]+attached[\s\n]+to[\s\n]+this[\s\n]+IS\),[\s\n]+you[\s\n]+consent[\s\n]+to[\s\n]+the[\s\n]+following[\s\n]+conditions\:(?:[\n]+|(?:\\n)+)\-The[\s\n]+USG[\s\n]+routinely[\s\n]+intercepts[\s\n]+and[\s\n]+monitors[\s\n]+communications[\s\n]+on[\s\n]+this[\s\n]+IS[\s\n]+for[\s\n]+purposes[\s\n]+including,[\s\n]+but[\s\n]+not[\s\n]+limited[\s\n]+to,[\s\n]+penetration[\s\n]+testing,[\s\n]+COMSEC[\s\n]+monitoring,[\s\n]+network[\s\n]+operations[\s\n]+and[\s\n]+defense,[\s\n]+personnel[\s\n]+misconduct[\s\n]+\(PM\),[\s\n]+law[\s\n]+enforcement[\s\n]+\(LE\),[\s\n]+and[\s\n]+counterintelligence[\s\n]+\(CI\)[\s\n]+investigations\.(?:[\n]+|(?:\\n)+)\-At[\s\n]+any[\s\n]+time,[\s\n]+the[\s\n]+USG[\s\n]+may[\s\n]+inspect[\s\n]+and[\s\n]+seize[\s\n]+data[\s\n]+stored[\s\n]+on[\s\n]+this[\s\n]+IS\.(?:[\n]+|(?:\\n)+)\-Communications[\s\n]+using,[\s\n]+or[\s\n]+data[\s\n]+stored[\s\n]+on,[\s\n]+this[\s\n]+IS[\s\n]+are[\s\n]+not[\s\n]+private,[\s\n]+are[\s\n]+subject[\s\n]+to[\s\n]+routine[\s\n]+monitoring,[\s\n]+interception,[\s\n]+and[\s\n]+search,[\s\n]+and[\s\n]+may[\s\n]+be[\s\n]+disclosed[\s\n]+or[\s\n]+used[\s\n]+for[\s\n]+any[\s\n]+USG\-authorized[\s\n]+purpose\.(?:[\n]+|(?:\\n)+)\-This[\s\n]+IS[\s\n]+includes[\s\n]+security[\s\n]+measures[\s\n]+\(e\.g\.,[\s\n]+authentication[\s\n]+and[\s\n]+access[\s\n]+controls\)[\s\n]+to[\s\n]+protect[\s\n]+USG[\s\n]+interests\-\-not[\s\n]+for[\s\n]+your[\s\n]+personal[\s\n]+benefit[\s\n]+or[\s\n]+privacy\.(?:[\n]+|(?:\\n)+)\-Notwithstanding[\s\n]+the[\s\n]+above,[\s\n]+using[\s\n]+this[\s\n]+IS[\s\n]+does[\s\n]+not[\s\n]+constitute[\s\n]+consent[\s\n]+to[\s\n]+PM,[\s\n]+LE[\s\n]+or[\s\n]+CI[\s\n]+investigative[\s\n]+searching[\s\n]+or[\s\n]+monitoring[\s\n]+of[\s\n]+the[\s\n]+content[\s\n]+of[\s\n]+privileged[\s\n]+communications,[\s\n]+or[\s\n]+work[\s\n]+product,[\s\n]+related[\s\n]+to[\s\n]+personal[\s\n]+representation[\s\n]+or[\s\n]+services[\s\n]+by[\s\n]+attorneys,[\s\n]+psychotherapists,[\s\n]+or[\s\n]+clergy,[\s\n]+and[\s\n]+their[\s\n]+assistants\.[\s\n]+Such[\s\n]+communications[\s\n]+and[\s\n]+work[\s\n]+product[\s\n]+are[\s\n]+private[\s\n]+and[\s\n]+confidential\.[\s\n]+See[\s\n]+User[\s\n]+Agreement[\s\n]+for[\s\n]+details\.|I've[\s\n]+read[\s\n]+\&amp;[\s\n]+consent[\s\n]+to[\s\n]+terms[\s\n]+in[\s\n]+IS[\s\n]+user[\s\n]+agreem't\.)$</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_login_banner_text" selected="true"/>
-    <!--1.8.3 Ensure GDM disable-user-list option is enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_disable_user_list" selected="true"/>
-    <!--1.8.4 Ensure GDM screen locks when the user is idle (Automated)-->
+    <!--UBTU-22-271020 The Ubuntu operating system must retain a user's session lock until that user reestablishes access using established identification and authentication procedures.-->
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_screensaver_lock_enabled" selected="true"/>
-    <!--1.8.5 Ensure GDM screen locks cannot be overridden (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_screensaver_lock_delay" selected="true"/>
-    <!--1.8.6 Ensure GDM automatic mounting of removable media is disabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_disable_automount" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_disable_automount_open" selected="true"/>
-    <!--1.8.8 Ensure GDM autorun-never is enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_disable_autorun" selected="true"/>
-    <!--1.8.10 Ensure XDCMP is not enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_gnome_gdm_disable_xdmcp" selected="true"/>
-    <!--2.1.1.1 Ensure a single time synchronization is in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_chrony_installed" selected="false"/>
-    <select idref="xccdf_org.ssgproject.content_rule_package_ntp_installed" selected="false"/>
-    <select idref="xccdf_org.ssgproject.content_rule_package_timesyncd_installed" selected="true"/>
-    <!--2.1.2.2 Ensure chrony is running as user _chrony (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_chronyd_run_as_chrony_user" selected="true"/>
-    <!--2.1.2.3 Ensure chrony is enabled and running (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_service_chronyd_enabled" selected="true"/>
-    <!--2.1.3.2 Ensure systemd-timesyncd is enabled and running (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_service_timesyncd_enabled" selected="true"/>
-    <!--2.1.4.1 Ensure ntp access control is configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_ntpd_configure_restrictions" selected="true"/>
-    <!--2.1.4.3 Ensure ntp is running as user ntp (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_ntpd_run_as_ntp_user" selected="true"/>
-    <!--2.1.4.4 Ensure ntp is enabled and running (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_service_ntp_enabled" selected="true"/>
-    <!--2.2.1 Ensure X Window System is not installed (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_xorg-x11-server-common_removed" selected="true"/>
-    <!--2.2.2 Ensure Avahi Server is not installed (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_service_avahi-daemon_disabled" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_package_avahi_removed" selected="true"/>
-    <!--2.2.3 Ensure CUPS is not installed (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_service_cups_disabled" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_package_cups_removed" selected="true"/>
-    <!--2.2.4 Ensure DHCP Server is not installed (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dhcp_removed" selected="true"/>
-    <!--2.2.5 Ensure LDAP server is not installed (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_openldap-servers_removed" selected="true"/>
-    <!--2.2.6 Ensure NFS is not installed (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_nfs-kernel-server_removed" selected="true"/>
-    <!--2.2.7 Ensure DNS Server is not installed (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_bind_removed" selected="true"/>
-    <!--2.2.8 Ensure FTP Server is not installed (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_vsftpd_removed" selected="true"/>
-    <!--2.2.9 Ensure HTTP server is not installed (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_httpd_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_package_nginx_removed" selected="true"/>
-    <!--2.2.10 Ensure IMAP and POP3 server are not installed (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dovecot_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_package_cyrus-imapd_removed" selected="true"/>
-    <!--2.2.11 Ensure Samba is not installed (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_samba_removed" selected="true"/>
-    <!--2.2.12 Ensure HTTP Proxy Server is not installed (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_squid_removed" selected="true"/>
-    <!--2.2.13 Ensure SNMP Server is not installed (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_net-snmp_removed" selected="true"/>
-    <!--2.2.14 Ensure NIS Server is not installed (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_nis_removed" selected="true"/>
-    <!--2.2.15 Ensure mail transfer agent is configured for local-only mode (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_postfix_inet_interfaces">loopback-only</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_postfix_network_listening_disabled" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_has_nonlocal_mta" selected="true"/>
-    <!--2.2.16 Ensure rsync service is not installed (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_rsync_removed" selected="true"/>
-    <!--2.3.2 Ensure rsh client is not installed (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_rsh_removed" selected="true"/>
-    <!--2.3.3 Ensure talk client is not installed (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_talk_removed" selected="true"/>
-    <!--2.3.4 Ensure telnet client is not installed (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_telnet_removed" selected="true"/>
-    <!--2.3.5 Ensure LDAP client is not installed (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_openldap-clients_removed" selected="true"/>
-    <!--2.3.6 Ensure RPC is not installed (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_rpcbind_removed" selected="true"/>
-    <!--3.1.2 Ensure wireless interfaces are disabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_wireless_disable_interfaces" selected="true"/>
-    <!--3.2.1 Ensure packet redirect sending is disabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_send_redirects" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_send_redirects" selected="true"/>
-    <!--3.2.2 Ensure IP forwarding is disabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_ip_forward" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_forwarding" selected="true"/>
-    <!--3.3.1 Ensure source routed packets are not accepted (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_accept_source_route" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_accept_source_route" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_accept_source_route" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_default_accept_source_route" selected="true"/>
-    <!--3.3.2 Ensure ICMP redirects are not accepted (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_accept_redirects" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_accept_redirects" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_accept_redirects" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_default_accept_redirects" selected="true"/>
-    <!--3.3.3 Ensure secure ICMP redirects are not accepted (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_secure_redirects" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_secure_redirects" selected="true"/>
-    <!--3.3.4 Ensure suspicious packets are logged (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_log_martians" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_log_martians" selected="true"/>
-    <!--3.3.5 Ensure broadcast ICMP requests are ignored (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_icmp_echo_ignore_broadcasts" selected="true"/>
-    <!--3.3.6 Ensure bogus ICMP responses are ignored (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_icmp_ignore_bogus_error_responses" selected="true"/>
-    <!--3.3.7 Ensure Reverse Path Filtering is enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_rp_filter" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_rp_filter" selected="true"/>
-    <!--3.3.8 Ensure TCP SYN Cookies is enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_tcp_syncookies" selected="true"/>
-    <!--3.3.9 Ensure IPv6 router advertisements are not accepted (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_accept_ra" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_default_accept_ra" selected="true"/>
-    <!--3.5.1.1 Ensure ufw is installed (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_ufw_installed" selected="false"/>
-    <!--3.5.1.2 Ensure iptables-persistent is not installed with ufw (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_iptables-persistent_removed" selected="true"/>
-    <!--3.5.1.3 Ensure ufw service is enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_service_ufw_enabled" selected="true"/>
-    <!--3.5.1.4 Ensure ufw loopback traffic is configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_set_ufw_loopback_traffic" selected="true"/>
-    <!--3.5.1.6 Ensure ufw firewall rules exist for all open ports (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_ufw_rules_for_open_ports" selected="true"/>
-    <!--3.5.1.7 Ensure ufw default deny firewall policy (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_set_ufw_default_rule" selected="true"/>
-    <!--3.5.2.1 Ensure nftables is installed (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_nftables_installed" selected="true"/>
-    <!--3.5.2.2 Ensure ufw is uninstalled or disabled with nftables (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_ufw_removed" selected="true"/>
-    <!--3.5.2.4 Ensure a nftables table exists (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_nftables_family">inet</set-value>
-    <set-value idref="xccdf_org.ssgproject.content_value_var_nftables_table">filter</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_set_nftables_table" selected="false"/>
-    <!--3.5.2.5 Ensure nftables base chains exist (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_set_nftables_base_chain" selected="false"/>
-    <!--3.5.2.6 Ensure nftables loopback traffic is configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_set_nftables_loopback_traffic" selected="false"/>
-    <!--3.5.2.8 Ensure nftables default deny firewall policy (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_nftables_ensure_default_deny_policy" selected="false"/>
-    <!--3.5.2.9 Ensure nftables service is enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_service_nftables_enabled" selected="false"/>
-    <!--3.5.2.10 Ensure nftables rules are permanent (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_nftable_master_config_file">/etc/nftables.conf</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_nftables_rules_permanent" selected="false"/>
-    <!--3.5.3.1.1 Ensure iptables packages are installed (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_iptables_installed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_package_iptables-persistent_installed" selected="false"/>
-    <!--3.5.3.1.2 Ensure nftables is not installed with iptables (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_service_nftables_disabled" selected="false"/>
-    <select idref="xccdf_org.ssgproject.content_rule_package_nftables_removed" selected="false"/>
-    <!--3.5.3.2.1 Ensure iptables default deny firewall policy (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_set_iptables_default_rule" selected="true"/>
-    <!--3.5.3.2.2 Ensure iptables loopback traffic is configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_set_loopback_traffic" selected="true"/>
-    <!--3.5.3.2.4 Ensure iptables firewall rules exist for all open ports (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_iptables_rules_for_open_ports" selected="true"/>
-    <!--3.5.3.3.1 Ensure ip6tables default deny firewall policy (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_set_ip6tables_default_rule" selected="true"/>
-    <!--3.5.3.3.2 Ensure ip6tables loopback traffic is configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_set_ipv6_loopback_traffic" selected="true"/>
-    <!--3.5.3.3.4 Ensure ip6tables firewall rules exist for all open ports (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_ip6tables_rules_for_open_ports" selected="true"/>
-    <!--4.1.4.1 Ensure audit log files are mode 0640 or less permissive (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_var_log_audit" selected="true"/>
-    <!--4.1.4.2 Ensure only authorized users own audit log files (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_ownership_var_log_audit_stig" selected="true"/>
-    <!--4.1.4.3 Ensure only authorized groups are assigned ownership of audit log files (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_group_ownership_var_log_audit" selected="true"/>
-    <!--4.1.4.4 Ensure the audit log directory is 0750 or more restrictive (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_directory_permissions_var_log_audit" selected="true"/>
-    <!--4.1.4.5 Ensure audit configuration files are 640 or more restrictive (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_audit_rulesd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_audit_auditd" selected="true"/>
-    <!--4.1.4.6 Ensure audit configuration files are owned by root (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_ownership_audit_configuration" selected="true"/>
-    <!--4.1.4.7 Ensure audit configuration files belong to group root (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupownership_audit_configuration" selected="true"/>
-    <!--4.1.4.8 Ensure audit tools are 755 or more restrictive (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_audit_binaries" selected="true"/>
-    <!--4.1.4.9 Ensure audit tools are owned by root (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_ownership_audit_binaries" selected="true"/>
-    <!--4.1.4.10 Ensure audit tools belong to group root (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupownership_audit_binaries" selected="true"/>
-    <!--4.1.4.11 Ensure cryptographic mechanisms are used to protect the integrity of audit tools (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_aide_check_audit_tools" selected="true"/>
-    <!--4.2.1.1.1 Ensure systemd-journal-remote is installed (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_systemd-journal-remote_installed" selected="true"/>
-    <!--4.2.1.1.4 Ensure journald is not configured to receive logs from a remote client (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_socket_systemd-journal-remote_disabled" selected="true"/>
-    <!--4.2.1.2 Ensure journald service is enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_service_systemd-journald_enabled" selected="true"/>
-    <!--4.2.1.3 Ensure journald is configured to compress large log files (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_journald_compress" selected="true"/>
-    <!--4.2.1.4 Ensure journald is configured to write logfiles to persistent disk (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_journald_storage" selected="true"/>
-    <!--4.2.2.1 Ensure rsyslog is installed (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_rsyslog_installed" selected="true"/>
-    <!--4.2.2.2 Ensure rsyslog service is enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_service_rsyslog_enabled" selected="true"/>
-    <!--4.2.2.4 Ensure rsyslog default file permissions are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_rsyslog_filecreatemode" selected="true"/>
-    <!--4.2.2.6 Ensure rsyslog is configured to send logs to a remote log host (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_rsyslog_remote_loghost" selected="true"/>
-    <!--4.2.2.7 Ensure rsyslog is not configured to receive logs from a remote client (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_rsyslog_nolisten" selected="true"/>
-    <!--4.2.3 Ensure all logfiles have appropriate permissions and ownership (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_permissions_local_var_log" selected="false"/>
-    <!--5.1.1 Ensure cron daemon is enabled and running (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_service_cron_enabled" selected="true"/>
-    <!--5.1.2 Ensure permissions on /etc/crontab are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_crontab" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_crontab" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_crontab" selected="true"/>
-    <!--5.1.3 Ensure permissions on /etc/cron.hourly are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_cron_hourly" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_cron_hourly" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_cron_hourly" selected="true"/>
-    <!--5.1.4 Ensure permissions on /etc/cron.daily are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_cron_daily" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_cron_daily" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_cron_daily" selected="true"/>
-    <!--5.1.5 Ensure permissions on /etc/cron.weekly are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_cron_weekly" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_cron_weekly" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_cron_weekly" selected="true"/>
-    <!--5.1.6 Ensure permissions on /etc/cron.monthly are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_cron_monthly" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_cron_monthly" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_cron_monthly" selected="true"/>
-    <!--5.1.7 Ensure permissions on /etc/cron.d are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_cron_d" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_cron_d" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_cron_d" selected="true"/>
-    <!--5.1.8 Ensure cron is restricted to authorized users (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_cron_deny_not_exist" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_cron_allow" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_cron_allow" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_cron_allow" selected="true"/>
-    <!--5.1.9 Ensure at is restricted to authorized users (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_at_deny_not_exist" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_at_allow" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_at_allow" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_at_allow" selected="true"/>
-    <!--5.2.1 Ensure permissions on /etc/ssh/sshd_config are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_config" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_sshd_config" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_sshd_config" selected="true"/>
-    <!--5.2.2 Ensure permissions on SSH private host key files are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key" selected="true"/>
-    <!--5.2.3 Ensure permissions on SSH public host key files are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_pub_key" selected="true"/>
-    <!--5.2.4 Ensure SSH access is limited (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_limit_user_access" selected="true"/>
-    <!--5.2.5 Ensure SSH LogLevel is appropriate (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_loglevel_info" selected="true"/>
-    <!--5.2.6 Ensure SSH PAM is enabled (Automated)-->
+    <!--UBTU-22-412025 The Ubuntu operating system must allow users to directly initiate a session lock for all connection types.-->
+    <select idref="xccdf_org.ssgproject.content_rule_vlock_installed" selected="true"/>
+    <!--UBTU-22-612040 The Ubuntu operating system must map the authenticated identity to the user or group account for PKI-based authentication.-->
+    <select idref="xccdf_org.ssgproject.content_rule_verify_use_mappers" selected="true"/>
+    <!--UBTU-22-411025 The Ubuntu operating system must enforce 24 hours/one day as the minimum password lifetime. Passwords for new users must have a 24 hours/one day minimum password lifetime restriction.-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_accounts_minimum_age_login_defs">1</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_minimum_age_login_defs" selected="true"/>
+    <!--UBTU-22-411030 The Ubuntu operating system must enforce a 60-day maximum password lifetime restriction. Passwords for new users must have a 60-day maximum password lifetime restriction.-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_accounts_maximum_age_login_defs">60</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_maximum_age_login_defs" selected="true"/>
+    <!--UBTU-22-212010 Ubuntu operating systems when booted must require authentication upon booting into single-user and maintenance modes.-->
+    <select idref="xccdf_org.ssgproject.content_rule_grub2_uefi_password" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_grub2_password" selected="true"/>
+    <!--UBTU-22-411015 The Ubuntu operating system must uniquely identify interactive users.-->
+    <select idref="xccdf_org.ssgproject.content_rule_no_duplicate_uids" selected="true"/>
+    <!--UBTU-22-432015 The Ubuntu operating system must ensure only users who need access to security functions are part of sudo group.-->
+    <select idref="xccdf_org.ssgproject.content_rule_ensure_sudo_group_restricted" selected="true"/>
+    <!--UBTU-22-412030 The Ubuntu operating system must automatically terminate a user session after inactivity timeouts have expired.-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_accounts_tmout">900</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_tmout" selected="true"/>
+    <!--UBTU-22-432010 The Ubuntu operating system must require users to reauthenticate for privilege escalation or when changing roles.-->
+    <select idref="xccdf_org.ssgproject.content_rule_sudo_require_authentication" selected="true"/>
+    <!--UBTU-22-412035 The Ubuntu operating system default filesystem permissions must be defined in such a way that all authenticated users can read and modify only their own files.-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_accounts_user_umask">077</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_umask_etc_login_defs" selected="true"/>
+    <!--UBTU-22-612010 The Ubuntu operating system must implement multifactor authentication for remote access to privileged accounts in such a way that one of the factors is provided by a device separate from the system gaining access.-->
+    <select idref="xccdf_org.ssgproject.content_rule_install_smartcard_packages" selected="true"/>
+    <!--UBTU-22-612020 The Ubuntu operating system must implement smart card logins for multifactor authentication for local and network access to privileged and non-privileged accounts.-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_pubkey_auth" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_smartcard_pam_enabled" selected="true"/>
+    <!--UBTU-22-255065 The Ubuntu operating system must use strong authenticators in establishing nonlocal maintenance and diagnostic sessions.-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_pam" selected="true"/>
-    <!--5.2.7 Ensure SSH root login is disabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_root_login" selected="true"/>
-    <!--5.2.8 Ensure SSH HostbasedAuthentication is disabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_disable_host_auth" selected="true"/>
-    <!--5.2.9 Ensure SSH PermitEmptyPasswords is disabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_empty_passwords" selected="true"/>
-    <!--5.2.10 Ensure SSH PermitUserEnvironment is disabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_do_not_permit_user_env" selected="true"/>
-    <!--5.2.11 Ensure SSH IgnoreRhosts is enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_rhosts" selected="true"/>
-    <!--5.2.13 Ensure only strong Ciphers are used (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_use_strong_ciphers" selected="true"/>
-    <!--5.2.14 Ensure only strong MAC algorithms are used (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_use_strong_macs" selected="true"/>
-    <!--5.2.15 Ensure only strong Key Exchange algorithms are used (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_sshd_strong_kex">ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_use_strong_kex" selected="true"/>
-    <!--5.2.17 Ensure SSH warning banner is configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_warning_banner_net" selected="true"/>
-    <!--5.2.18 Ensure SSH MaxAuthTries is set to 4 or less (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_sshd_max_auth_tries_value">4</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_max_auth_tries" selected="true"/>
-    <!--5.2.19 Ensure SSH MaxStartups is configured (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_sshd_set_maxstartups">10:30:60</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_maxstartups" selected="true"/>
-    <!--5.2.20 Ensure SSH MaxSessions is set to 10 or less (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_sshd_max_sessions">10</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_max_sessions" selected="true"/>
-    <!--5.2.21 Ensure SSH LoginGraceTime is set to one minute or less (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_sshd_set_login_grace_time">60</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_login_grace_time" selected="true"/>
-    <!--5.2.22 Ensure SSH Idle Timeout Interval is configured (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_sshd_idle_timeout_value">300</set-value>
-    <set-value idref="xccdf_org.ssgproject.content_value_var_sshd_set_keepalive">3</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_idle_timeout" selected="true"/>
+    <!--UBTU-22-255030 The Ubuntu operating system must immediately terminate all network connections associated with SSH traffic after a period of inactivity.-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_sshd_set_keepalive">1</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_sshd_set_keepalive" selected="true"/>
-    <!--5.3.1 Ensure sudo is installed (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_sudo_installed" selected="true"/>
-    <!--5.3.2 Ensure sudo commands use pty (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sudo_add_use_pty" selected="true"/>
-    <!--5.3.3 Ensure sudo log file exists (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sudo_custom_logfile" selected="true"/>
-    <!--5.3.5 Ensure re-authentication for privilege escalation is not disabled globally (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sudo_remove_no_authenticate" selected="true"/>
-    <!--5.3.6 Ensure sudo authentication timeout is configured correctly (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_sudo_timestamp_timeout">15</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_sudo_require_reauthentication" selected="true"/>
-    <!--5.3.7 Ensure access to the su command is restricted (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_pam_wheel_group_for_su">sugroup</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_use_pam_wheel_group_for_su" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_ensure_pam_wheel_group_empty" selected="true"/>
-    <!--5.4.1 Ensure password creation requirements are configured (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_password_pam_minlen">14</set-value>
-    <set-value idref="xccdf_org.ssgproject.content_value_var_password_pam_minclass">4</set-value>
-    <set-value idref="xccdf_org.ssgproject.content_value_var_password_pam_dcredit">-1</set-value>
+    <!--UBTU-22-255035 The Ubuntu operating system must immediately terminate all network connections associated with SSH traffic at the end of the session or after 10 minutes of inactivity.-->
+    <set-value idref="xccdf_org.ssgproject.content_value_sshd_idle_timeout_value">600</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_idle_timeout" selected="true"/>
+    <!--UBTU-22-255010 The Ubuntu operating system must use SSH to protect the confidentiality and integrity of transmitted information.-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_openssh-server_installed" selected="true"/>
+    <!--UBTU-22-255015 The Ubuntu operating system must use SSH to protect the confidentiality and integrity of transmitted information.-->
+    <select idref="xccdf_org.ssgproject.content_rule_service_sshd_enabled" selected="true"/>
+    <!--UBTU-22-255020 The Ubuntu operating system must display the Standard Mandatory DoD Notice and Consent Banner before granting any local or remote connection to the system.-->
+    <select idref="xccdf_org.ssgproject.content_rule_banner_etc_issue_net" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_warning_banner_net" selected="true"/>
+    <!--UBTU-22-255055 The Ubuntu operating system must configure the SSH daemon to use Message Authentication Codes (MACs) employing FIPS 140-3 approved cryptographic hashes to prevent the unauthorized disclosure of information and/or detect changes to information during transmission.-->
+    <set-value idref="xccdf_org.ssgproject.content_value_sshd_approved_macs">hmac-sha2-512,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-256-etm@openssh.com</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_use_approved_macs_ordered_stig" selected="true"/>
+    <!--UBTU-22-255050 The Ubuntu operating system must configure the SSH daemon to use FIPS 140-3 approved ciphers to prevent the unauthorized disclosure of information and/or detect changes to information during transmission.-->
+    <set-value idref="xccdf_org.ssgproject.content_value_sshd_approved_ciphers">aes256-ctr,aes256-gcm@openssh.com,aes192-ctr,aes128-ctr,aes128-gcm@openssh.com</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_use_approved_ciphers_ordered_stig" selected="true"/>
+    <!--UBTU-22-255060 The Ubuntu operating system SSH server must be configured to use only FIPS-validated key exchange algorithms.-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_use_approved_kex_ordered_stig" selected="true"/>
+    <!--UBTU-22-255025 The Ubuntu operating system must not allow unattended or automatic login via SSH.-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_empty_passwords" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_do_not_permit_user_env" selected="true"/>
+    <!--UBTU-22-255040 The Ubuntu operating system must be configured so that remote X connections are disabled, unless to fulfill documented and validated mission requirements.-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_x11_forwarding" selected="true"/>
+    <!--UBTU-22-255045 The Ubuntu operating system SSH daemon must prevent remote hosts from connecting to the proxy display.-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_x11_use_localhost" selected="true"/>
+    <!--UBTU-22-611010 The Ubuntu operating system must enforce password complexity by requiring that at least one upper-case character be used.-->
     <set-value idref="xccdf_org.ssgproject.content_value_var_password_pam_ucredit">-1</set-value>
-    <set-value idref="xccdf_org.ssgproject.content_value_var_password_pam_ocredit">-1</set-value>
-    <set-value idref="xccdf_org.ssgproject.content_value_var_password_pam_lcredit">-1</set-value>
-    <set-value idref="xccdf_org.ssgproject.content_value_var_password_pam_retry">3</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_password_pam_minlen" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_password_pam_minclass" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_password_pam_dcredit" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_accounts_password_pam_ucredit" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_password_pam_ocredit" selected="true"/>
+    <!--UBTU-22-611015 The Ubuntu operating system must enforce password complexity by requiring that at least one lower-case character be used.-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_password_pam_lcredit">-1</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_accounts_password_pam_lcredit" selected="true"/>
+    <!--UBTU-22-611020 The Ubuntu operating system must enforce password complexity by requiring that at least one numeric character be used.-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_password_pam_dcredit">-1</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_password_pam_dcredit" selected="true"/>
+    <!--UBTU-22-611040 The Ubuntu operating system must require the change of at least 8 characters when passwords are changed.-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_password_pam_difok">8</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_password_pam_difok" selected="true"/>
+    <!--UBTU-22-611035 The Ubuntu operating system must enforce a minimum 15-character password length.-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_password_pam_minlen">15</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_password_pam_minlen" selected="true"/>
+    <!--UBTU-22-611025 The Ubuntu operating system must enforce password complexity by requiring that at least one special character be used.-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_password_pam_ocredit">-1</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_password_pam_ocredit" selected="true"/>
+    <!--UBTU-22-611030 The Ubuntu operating system must prevent the use of dictionary words for passwords.-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_password_pam_dictcheck">1</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_password_pam_dictcheck" selected="true"/>
+    <!--UBTU-22-215010 The Ubuntu operating system must be configured so that when passwords are changed or new passwords are established, pwquality must be used.-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_pam_pwquality_installed" selected="true"/>
+    <!--UBTU-22-611045 The Ubuntu operating system must be configured so that when passwords are changed or new passwords are established, pwquality must be used.-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_password_pam_retry">3</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_password_pam_enforcing" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_accounts_password_pam_retry" selected="true"/>
-    <!--5.4.2 Ensure lockout for failed password attempts is configured (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_accounts_passwords_pam_faillock_deny">4</set-value>
+    <!--UBTU-22-612030 The Ubuntu operating system, for PKI-based authentication, must validate certificates by constructing a certification path (which includes status information) to an accepted trust anchor.-->
+    <select idref="xccdf_org.ssgproject.content_rule_smartcard_configure_ca" selected="true"/>
+    <!--UBTU-22-612015 The Ubuntu operating system must accept Personal Identity Verification (PIV) credentials.-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_opensc_installed" selected="true"/>
+    <!--UBTU-22-612025 The Ubuntu operating system must electronically verify Personal Identity Verification (PIV) credentials.-->
+    <select idref="xccdf_org.ssgproject.content_rule_smartcard_configure_cert_checking" selected="true"/>
+    <!--UBTU-22-612035 The Ubuntu operating system for PKI-based authentication, must implement a local cache of revocation data in case of the inability to access revocation information via the network.-->
+    <select idref="xccdf_org.ssgproject.content_rule_smartcard_configure_crl" selected="true"/>
+    <!--UBTU-22-411045 The Ubuntu operating system must automatically lock an account until the locked account is released by an administrator when three unsuccessful logon attempts have been made.-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_accounts_passwords_pam_faillock_deny">3</set-value>
     <set-value idref="xccdf_org.ssgproject.content_value_var_accounts_passwords_pam_faillock_fail_interval">900</set-value>
-    <set-value idref="xccdf_org.ssgproject.content_value_var_accounts_passwords_pam_faillock_unlock_time">600</set-value>
+    <set-value idref="xccdf_org.ssgproject.content_value_var_accounts_passwords_pam_faillock_unlock_time">0</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_passwords_pam_faillock_audit" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_passwords_pam_faillock_silent" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_accounts_passwords_pam_faillock_deny" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_accounts_passwords_pam_faillock_interval" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_accounts_passwords_pam_faillock_unlock_time" selected="true"/>
-    <!--5.4.3 Ensure password reuse is limited (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_password_pam_remember">5</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_password_pam_unix_remember" selected="true"/>
-    <!--5.4.4 Ensure password hashing algorithm is up to date with the latest standards (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_password_hashing_algorithm">yescrypt</set-value>
+    <!--UBTU-22-651025 The Ubuntu operating system must be configured so that the script which runs each 30 days or less to check file integrity is the default one.-->
+    <select idref="xccdf_org.ssgproject.content_rule_aide_periodic_cron_checking" selected="true"/>
+    <!--UBTU-22-412010 The Ubuntu operating system must enforce a delay of at least 4 seconds between logon prompts following a failed logon attempt.-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_password_pam_delay">4000000</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_passwords_pam_faildelay_delay" selected="true"/>
+    <!--UBTU-22-654145 The Ubuntu operating system must generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/passwd.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_usergroup_modification_passwd" selected="true"/>
+    <!--UBTU-22-654130 The Ubuntu operating system must generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/group.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_usergroup_modification_group" selected="true"/>
+    <!--UBTU-22-654150 The Ubuntu operating system must generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/shadow.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_usergroup_modification_shadow" selected="true"/>
+    <!--UBTU-22-654135 The Ubuntu operating system must generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/gshadow.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_usergroup_modification_gshadow" selected="true"/>
+    <!--UBTU-22-654140 The Ubuntu operating system must generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/opasswd.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_usergroup_modification_opasswd" selected="true"/>
+    <!--UBTU-22-653025 The Ubuntu operating system must alert the ISSO and SA (at a minimum) in the event of an audit processing failure.-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_auditd_action_mail_acct">root</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_auditd_data_retention_action_mail_acct" selected="true"/>
+    <!--UBTU-22-653030 The Ubuntu operating system must shut down by default upon audit failure (unless availability is an overriding concern).-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_auditd_disk_full_action">halt</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_auditd_data_disk_full_action" selected="true"/>
+    <!--UBTU-22-653045 The Ubuntu operating system must be configured so that audit log files are not read or write-accessible by unauthorized users.-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_var_log_audit_stig" selected="true"/>
+    <!--UBTU-22-653050 The Ubuntu operating system must be configured to permit only authorized users ownership of the audit log files.-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_ownership_var_log_audit_stig" selected="true"/>
+    <!--UBTU-22-653055 The Ubuntu operating system must permit only authorized groups ownership of the audit log files.-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_group_ownership_var_log_audit_stig" selected="true"/>
+    <!--UBTU-22-653060 The Ubuntu operating system must be configured so that the audit log directory is not write-accessible by unauthorized users.-->
+    <select idref="xccdf_org.ssgproject.content_rule_directory_permissions_var_log_audit" selected="true"/>
+    <!--UBTU-22-653065 The Ubuntu operating system must be configured so that audit configuration files are not write-accessible by unauthorized users.-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_audit_rules" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_audit_rulesd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_audit_auditd" selected="true"/>
+    <!--UBTU-22-653070 The Ubuntu operating system must permit only authorized accounts to own the audit configuration files.-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_ownership_audit_configuration" selected="true"/>
+    <!--UBTU-22-653075 The Ubuntu operating system must permit only authorized groups to own the audit configuration files.-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupownership_audit_configuration" selected="true"/>
+    <!--UBTU-22-654100 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the su command.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_su" selected="true"/>
+    <!--UBTU-22-654030 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the chfn command.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_chfn" selected="true"/>
+    <!--UBTU-22-654065 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the mount command.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_mount" selected="true"/>
+    <!--UBTU-22-654115 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the umount command.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_umount" selected="true"/>
+    <!--UBTU-22-654090 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the ssh-agent command.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_ssh_agent" selected="true"/>
+    <!--UBTU-22-654095 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the ssh-keysign command.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_ssh_keysign" selected="true"/>
+    <!--UBTU-22-654180 The Ubuntu operating system must generate audit records for any use of the setxattr, fsetxattr, lsetxattr, removexattr, fremovexattr, and lremovexattr system calls-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_setxattr" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_lsetxattr" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_fsetxattr" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_removexattr" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_lremovexattr" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_fremovexattr" selected="true"/>
+    <!--UBTU-22-654160 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the chown, fchown, fchownat, and lchown system calls.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_chown" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_fchown" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_fchownat" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_lchown" selected="true"/>
+    <!--UBTU-22-654155 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the chmod, fchmod, and fchmodat system calls.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_chmod" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_fchmod" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_fchmodat" selected="true"/>
+    <!--UBTU-22-654165 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the creat, open, openat, open_by_handle_at, truncate, and ftruncate system calls.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_open" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_truncate" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_ftruncate" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_creat" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_openat" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_open_by_handle_at" selected="true"/>
+    <!--UBTU-22-654105 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the sudo command.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_sudo" selected="true"/>
+    <!--UBTU-22-654110 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the sudoedit command.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_sudoedit" selected="true"/>
+    <!--UBTU-22-654035 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the chsh command.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_chsh" selected="true"/>
+    <!--UBTU-22-654070 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the newgrp command.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_newgrp" selected="true"/>
+    <!--UBTU-22-654025 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the chcon command.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_chcon" selected="true"/>
+    <!--UBTU-22-654010 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the apparmor_parser command.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_apparmor_parser" selected="true"/>
+    <!--UBTU-22-654085 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the setfacl command.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_setfacl" selected="true"/>
+    <!--UBTU-22-654015 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the chacl command.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_chacl" selected="true"/>
+    <!--UBTU-22-654210 The Ubuntu operating system must generate audit records for the use and modification of faillog file.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_login_events_faillog" selected="true"/>
+    <!--UBTU-22-654215 The Ubuntu operating system must generate audit records for the use and modification of the lastlog file.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_login_events_lastlog" selected="true"/>
+    <!--UBTU-22-654080 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the passwd command.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_passwd" selected="true"/>
+    <!--UBTU-22-654120 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the unix_update command.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_unix_update" selected="true"/>
+    <!--UBTU-22-654050 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the gpasswd command.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_gpasswd" selected="true"/>
+    <!--UBTU-22-654020 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the chage command.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_chage" selected="true"/>
+    <!--UBTU-22-654125 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the usermod command.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_usermod" selected="true"/>
+    <!--UBTU-22-654040 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the crontab command.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_crontab" selected="true"/>
+    <!--UBTU-22-654075 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the pam_timestamp_check command.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_pam_timestamp_check" selected="true"/>
+    <!--UBTU-22-654175 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the init_module and finit_module syscall.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_init" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_finit" selected="true"/>
+    <!--UBTU-22-654170 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the delete_module syscall-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_delete" selected="true"/>
+    <!--UBTU-22-653010 The Ubuntu operating system must have the "auditd" package installed-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_audit_installed" selected="true"/>
+    <!--UBTU-22-653015 The Ubuntu operating system must produce audit records and reports containing information to establish when, where, what type, the source, and the outcome for all DoD-defined auditable events and actions in near real time.-->
+    <select idref="xccdf_org.ssgproject.content_rule_service_auditd_enabled" selected="true"/>
+    <!--UBTU-22-212015 The Ubuntu operating system must initiate session audits at system start-up.-->
+    <select idref="xccdf_org.ssgproject.content_rule_grub2_audit_argument" selected="true"/>
+    <!--UBTU-22-232035 The Ubuntu operating system must configure audit tools with a mode of 0755 or less permissive.-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_audit_binaries" selected="true"/>
+    <!--UBTU-22-232110 The Ubuntu operating system must configure audit tools to be owned by root.-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_ownership_audit_binaries" selected="true"/>
+    <!--UBTU-22-651030 The Ubuntu operating system must use cryptographic mechanisms to protect the integrity of audit tools.-->
+    <select idref="xccdf_org.ssgproject.content_rule_aide_check_audit_tools" selected="true"/>
+    <!--UBTU-22-654230 The Ubuntu operating system must prevent all software from executing at higher privilege levels than users executing the software and the audit system must be configured to audit the execution of privileged functions.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_suid_privilege_function" selected="true"/>
+    <!--UBTU-22-653035 The Ubuntu operating system must allocate audit record storage capacity to store at least one weeks' worth of audit records, when audit records are not immediately sent to a central audit record storage facility.-->
+    <select idref="xccdf_org.ssgproject.content_rule_auditd_audispd_configure_sufficiently_large_partition" selected="true"/>
+    <!--UBTU-22-653020 The Ubuntu operating system audit event multiplexor must be configured to off-load audit logs onto a different system or storage media from the system being audited.-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_audit-audispd-plugins_installed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_auditd_audispd_configure_remote_server" selected="true"/>
+    <!--UBTU-22-653040 The Ubuntu operating system must immediately notify the SA and ISSO (at a minimum) when allocated audit record storage volume reaches 75% of the repository maximum audit record storage capacity.-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_auditd_space_left_percentage">25</set-value>
+    <set-value idref="xccdf_org.ssgproject.content_value_var_auditd_space_left_action">email</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_auditd_data_retention_space_left_action" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_auditd_data_retention_space_left_percentage" selected="true"/>
+    <!--UBTU-22-252020 The Ubuntu operating system must record time stamps for audit records that can be mapped to Coordinated Universal Time (UTC) or Greenwich Mean Time (GMT).-->
+    <select idref="xccdf_org.ssgproject.content_rule_ensure_rtc_utc_configuration" selected="true"/>
+    <!--UBTU-22-654235 The Ubuntu operating system must generate audit records for privileged activities, nonlocal maintenance, diagnostic sessions and other system-level access.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_sudo_log_events" selected="true"/>
+    <!--UBTU-22-654185 The Ubuntu operating system must generate audit records for any successful/unsuccessful use of unlink, unlinkat, rename, renameat, and rmdir system calls.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_unlink" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_rmdir" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_renameat" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_rename" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_unlinkat" selected="true"/>
+    <!--UBTU-22-654200 The Ubuntu operating system must generate audit records for the /var/log/wtmp file.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_session_events_wtmp" selected="true"/>
+    <!--UBTU-22-654205 The Ubuntu operating system must generate audit records for the /var/run/wtmp file.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_session_events_utmp" selected="true"/>
+    <!--UBTU-22-654195 The Ubuntu operating system must generate audit records for the /var/log/btmp file.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_session_events_btmp" selected="true"/>
+    <!--UBTU-22-654060 The Ubuntu operating system must generate audit records when successful/unsuccessful attempts to use modprobe command-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_modprobe" selected="true"/>
+    <!--UBTU-22-654055 The Ubuntu operating system must generate audit records when successful/unsuccessful attempts to use the kmod command.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_kmod" selected="true"/>
+    <!--UBTU-22-654045 The Ubuntu operating system must generate audit records when successful/unsuccessful attempts to use the fdisk command.-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_fdisk" selected="true"/>
+    <!--UBTU-22-651035 The Ubuntu operating system must have a crontab script running weekly to offload audit events of standalone systems.-->
+    <select idref="xccdf_org.ssgproject.content_rule_auditd_offload_logs" selected="true"/>
+    <!--UBTU-22-412020 The Ubuntu operating system must limit the number of concurrent sessions to ten for all accounts and/or account types.-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_accounts_max_concurrent_login_sessions">10</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_max_concurrent_login_sessions" selected="true"/>
+    <!--UBTU-22-213010 The Ubuntu operating system must restrict access to the kernel message buffer.-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_kernel_dmesg_restrict" selected="true"/>
+    <!--UBTU-22-652015 The Ubuntu operating system must monitor remote access methods.-->
+    <select idref="xccdf_org.ssgproject.content_rule_rsyslog_remote_access_monitoring" selected="true"/>
+    <!--UBTU-22-611070 The Ubuntu operating system must encrypt all stored passwords with a FIPS 140-3 approved cryptographic hashing algorithm.-->
     <select idref="xccdf_org.ssgproject.content_rule_set_password_hashing_algorithm_logindefs" selected="true"/>
-    <!--5.5.1.1 Ensure minimum days between password changes is configured (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_accounts_minimum_age_login_defs">1</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_minimum_age_login_defs" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_password_set_min_life_existing" selected="true"/>
-    <!--5.5.1.2 Ensure password expiration is 365 days or less (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_accounts_maximum_age_login_defs">365</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_maximum_age_login_defs" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_password_set_max_life_existing" selected="true"/>
-    <!--5.5.1.3 Ensure password expiration warning days is 7 or more (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_accounts_password_warn_age_login_defs">7</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_password_warn_age_login_defs" selected="true"/>
-    <!--5.5.1.4 Ensure inactive password lock is 30 days or less (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_account_disable_post_pw_expiration">30</set-value>
+    <!--UBTU-22-215035 The Ubuntu operating system must not have the telnet package installed.-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_telnetd_removed" selected="true"/>
+    <!--UBTU-22-215030 The Ubuntu operating system must not have the rsh-server package installed.-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_rsh-server_removed" selected="true"/>
+    <!--UBTU-22-251030 The Ubuntu operating system must be configured to prohibit or restrict the use of functions, ports, protocols, and/or services, as defined in the PPSM CAL and vulnerability assessments.-->
+    <select idref="xccdf_org.ssgproject.content_rule_ufw_only_required_services" selected="true"/>
+    <!--UBTU-22-411010 The Ubuntu operating system must prevent direct login into the root account.-->
+    <select idref="xccdf_org.ssgproject.content_rule_prevent_direct_root_logins" selected="true"/>
+    <!--UBTU-22-411035 The Ubuntu operating system must disable account identifiers (individuals, groups, roles, and devices) after 35 days of inactivity.-->
     <select idref="xccdf_org.ssgproject.content_rule_account_disable_post_pw_expiration" selected="true"/>
-    <!--5.5.1.5 Ensure all users last password change date is in the past (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_password_last_change_is_in_past" selected="true"/>
-    <!--5.5.2 Ensure system accounts are secured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_no_shelllogin_for_systemaccounts" selected="true"/>
-    <!--5.5.3 Ensure default group for the root account is GID 0 (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_root_gid_zero" selected="true"/>
-    <!--5.5.4 Ensure default user umask is 027 or more restrictive (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_accounts_user_umask">027</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_umask_etc_login_defs" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_umask_etc_profile" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_umask_etc_bashrc" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_umask_interactive_users" selected="true"/>
-    <!--5.5.5 Ensure default user shell timeout is 900 seconds or less (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_accounts_tmout">900</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_tmout" selected="true"/>
-    <!--6.1.1 Ensure permissions on /etc/passwd are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_passwd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_passwd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_passwd" selected="true"/>
-    <!--6.1.2 Ensure permissions on /etc/passwd- are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_backup_etc_passwd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_backup_etc_passwd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_backup_etc_passwd" selected="true"/>
-    <!--6.1.3 Ensure permissions on /etc/group are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_group" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_group" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_group" selected="true"/>
-    <!--6.1.4 Ensure permissions on /etc/group- are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_backup_etc_group" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_backup_etc_group" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_backup_etc_group" selected="true"/>
-    <!--6.1.5 Ensure permissions on /etc/shadow are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_shadow" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_shadow" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_shadow" selected="true"/>
-    <!--6.1.6 Ensure permissions on /etc/shadow- are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_backup_etc_shadow" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_backup_etc_shadow" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_backup_etc_shadow" selected="true"/>
-    <!--6.1.7 Ensure permissions on /etc/gshadow are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_gshadow" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_gshadow" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_gshadow" selected="true"/>
-    <!--6.1.8 Ensure permissions on /etc/gshadow- are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_backup_etc_gshadow" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_backup_etc_gshadow" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_backup_etc_gshadow" selected="true"/>
-    <!--6.1.9 Ensure no world writable files exist (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_unauthorized_world_writable" selected="true"/>
-    <!--6.1.10 Ensure no unowned files or directories exist (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_no_files_unowned_by_user" selected="true"/>
-    <!--6.1.11 Ensure no ungrouped files or directories exist (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned" selected="true"/>
-    <!--6.2.1 Ensure accounts in /etc/passwd use shadowed passwords (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_password_all_shadowed" selected="true"/>
-    <!--6.2.2 Ensure /etc/shadow password fields are not empty (Automated)-->
+    <!--UBTU-22-411040 The Ubuntu operating system must provision temporary user accounts with an expiration time of 72 hours or less.-->
+    <select idref="xccdf_org.ssgproject.content_rule_account_temp_expire_date" selected="true"/>
+    <!--UBTU-22-232145 The Ubuntu operating system must set a sticky bit  on all public directories to prevent unauthorized and unintended information transferred via shared system resources.-->
+    <select idref="xccdf_org.ssgproject.content_rule_dir_perms_world_writable_sticky_bits" selected="true"/>
+    <!--UBTU-22-253010 The Ubuntu operating system must be configured to use TCP syncookies.-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_tcp_syncookies" selected="true"/>
+    <!--UBTU-22-213015 The Ubuntu operating system must disable kernel core dumps  so that it can fail to a secure state if system initialization fails, shutdown fails or aborts fail.-->
+    <select idref="xccdf_org.ssgproject.content_rule_service_kdump_disabled" selected="true"/>
+    <!--UBTU-22-231010 Ubuntu operating systems handling data requiring "data at rest" protections must employ cryptographic mechanisms to prevent unauthorized disclosure and modification of the information at rest.-->
+    <select idref="xccdf_org.ssgproject.content_rule_encrypt_partitions" selected="true"/>
+    <!--UBTU-22-232026 The Ubuntu operating system must generate error messages that provide information necessary for corrective actions without revealing information that could be exploited by adversaries.-->
+    <select idref="xccdf_org.ssgproject.content_rule_permissions_local_var_log" selected="true"/>
+    <!--UBTU-22-232125 The Ubuntu operating system must configure the /var/log directory to be group-owned by syslog.-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_var_log" selected="true"/>
+    <!--UBTU-22-232120 The Ubuntu operating system must configure the /var/log directory to be owned by root.-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_var_log" selected="true"/>
+    <!--UBTU-22-232025 The Ubuntu operating system must configure the /var/log directory to have mode 0750 or less permissive.-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_var_log" selected="true"/>
+    <!--UBTU-22-232135 The Ubuntu operating system must configure the /var/log/syslog file to be group-owned by adm.-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_var_log_syslog" selected="true"/>
+    <!--UBTU-22-232130 The Ubuntu operating system must configure /var/log/syslog file to be owned by syslog.-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_var_log_syslog" selected="true"/>
+    <!--UBTU-22-232030 The Ubuntu operating system must configure /var/log/syslog file with mode 0640 or less permissive.-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_var_log_syslog" selected="true"/>
+    <!--UBTU-22-232010 The Ubuntu operating system must have directories that contain system commands set to a mode of 0755 or less permissive.-->
+    <select idref="xccdf_org.ssgproject.content_rule_dir_permissions_binary_dirs" selected="true"/>
+    <!--UBTU-22-232040 The Ubuntu operating system must have directories that contain system commands owned by root.-->
+    <select idref="xccdf_org.ssgproject.content_rule_dir_ownership_binary_dirs" selected="true"/>
+    <!--UBTU-22-232045 The Ubuntu operating system must have directories that contain system commands group-owned by root.-->
+    <select idref="xccdf_org.ssgproject.content_rule_dir_groupownership_binary_dirs" selected="true"/>
+    <!--UBTU-22-232020 The Ubuntu operating system library files must have mode 0755 or less permissive.-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_library_dirs" selected="true"/>
+    <!--UBTU-22-232070 The Ubuntu operating system library files must be owned by root.-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_ownership_library_dirs" selected="true"/>
+    <!--UBTU-22-232060 The Ubuntu operating system library directories must be owned by root.-->
+    <select idref="xccdf_org.ssgproject.content_rule_dir_ownership_library_dirs" selected="true"/>
+    <!--UBTU-22-232075 The Ubuntu operating system library files must be group-owned by root.-->
+    <select idref="xccdf_org.ssgproject.content_rule_root_permissions_syslibrary_files" selected="true"/>
+    <!--UBTU-22-232065 The Ubuntu operating system library directories must be group-owned by root.-->
+    <select idref="xccdf_org.ssgproject.content_rule_dir_group_ownership_library_dirs" selected="true"/>
+    <!--UBTU-22-652010 The Ubuntu operating system must be configured to preserve log records from failure events.-->
+    <select idref="xccdf_org.ssgproject.content_rule_service_rsyslog_enabled" selected="true"/>
+    <!--UBTU-22-251010 The Ubuntu operating system must have an application firewall installed in order to control remote access methods.-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_ufw_installed" selected="true"/>
+    <!--UBTU-22-215015 The Ubuntu operating system must have the "chrony" package installed-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_chrony_installed" selected="true"/>
+    <!--UBTU-22-252010 The Ubuntu operating system must, for networked systems, compare internal information system clocks at least every 24 hours with a server which is synchronized to one of the redundant United States Naval Observatory (USNO) time servers, or a time server designated for the appropriate DoD network (NIPRNet/SIPRNet), and/or the Global Positioning System (GPS).-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_time_service_set_maxpoll">16</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_chronyd_or_ntpd_set_maxpoll" selected="true"/>
+    <!--UBTU-22-252015 The Ubuntu operating system must synchronize internal information system clocks to the authoritative time source when the time difference is greater than one second.-->
+    <select idref="xccdf_org.ssgproject.content_rule_chronyd_sync_clock" selected="true"/>
+    <!--UBTU-22-651020 The Ubuntu operating system must notify designated personnel if baseline configurations are changed in an unauthorized manner. The file integrity tool must notify the System Administrator when changes to the baseline configuration or anomalies in the oper-->
+    <select idref="xccdf_org.ssgproject.content_rule_aide_disable_silentreports" selected="true"/>
+    <!--UBTU-22-214010 The Ubuntu operating system's Advance Package Tool (APT) must be configured to prevent the installation of patches, service packs, device drivers, or Ubuntu operating system components without verification they have been digitally signed using a certificate that is recognized and approved by the organization.-->
+    <select idref="xccdf_org.ssgproject.content_rule_apt_conf_disallow_unauthenticated" selected="true"/>
+    <!--UBTU-22-431010 The Ubuntu operating system must be configured to use AppArmor.-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_apparmor_installed" selected="true"/>
+    <!--UBTU-22-431015 The Ubuntu operating system must be configured to use AppArmor.-->
+    <select idref="xccdf_org.ssgproject.content_rule_apparmor_configured" selected="true"/>
+    <!--UBTU-22-631015 The Ubuntu operating system must be configured such that Pluggable Authentication Module (PAM) prohibits the use of cached authentications after one day.-->
+    <select idref="xccdf_org.ssgproject.content_rule_sssd_offline_cred_expiration" selected="true"/>
+    <!--UBTU-22-671010 The Ubuntu operating system must implement NIST FIPS-validated cryptography  to protect classified information and for the following: to provision digital signatures, to generate cryptographic hashes, and to protect unclassified information requiring confidentiality and cryptographic protection in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, and standards.-->
+    <select idref="xccdf_org.ssgproject.content_rule_is_fips_mode_enabled" selected="true"/>
+    <!--UBTU-22-631010 The Ubuntu operating system must only allow the use of DoD PKI-established certificate authorities for verification of the establishment of protected sessions.-->
+    <select idref="xccdf_org.ssgproject.content_rule_only_allow_dod_certs" selected="true"/>
+    <!--UBTU-22-251025 The Ubuntu operating system must configure the uncomplicated firewall to rate-limit impacted network interfaces.-->
+    <select idref="xccdf_org.ssgproject.content_rule_ufw_rate_limit" selected="true"/>
+    <!--UBTU-22-213025 The Ubuntu operating system must implement non-executable data to protect its memory from unauthorized code execution.-->
+    <select idref="xccdf_org.ssgproject.content_rule_bios_enable_execution_restrictions" selected="true"/>
+    <!--UBTU-22-213020 The Ubuntu operating system must implement address space layout randomization to protect its memory from unauthorized code execution.-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_kernel_randomize_va_space" selected="true"/>
+    <!--UBTU-22-214015 The Ubuntu operating system must be configured so that Advance Package Tool (APT) removes all software components after updated versions have been installed.-->
+    <select idref="xccdf_org.ssgproject.content_rule_clean_components_post_updating" selected="true"/>
+    <!--UBTU-22-651010 The Ubuntu operating system must use a file integrity tool to verify correct operation of all security functions.-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_aide_installed" selected="true"/>
+    <!--UBTU-22-651015 The Ubuntu operating system must use a file integrity tool to verify correct operation of all security functions.-->
+    <select idref="xccdf_org.ssgproject.content_rule_aide_build_database" selected="true"/>
+    <!--UBTU-22-412015 The Ubuntu operating system must display the date and time of the last successful account logon upon logon.-->
+    <select idref="xccdf_org.ssgproject.content_rule_display_login_attempts" selected="true"/>
+    <!--UBTU-22-251015 The Ubuntu operating system must enable and run the Uncomplicated Firewall (ufw).-->
+    <select idref="xccdf_org.ssgproject.content_rule_check_ufw_active" selected="true"/>
+    <!--UBTU-22-251020 The Ubuntu operating system must have an application firewall enabled.-->
+    <select idref="xccdf_org.ssgproject.content_rule_service_ufw_enabled" selected="true"/>
+    <!--UBTU-22-291015 The Ubuntu operating system must disable all wireless network adapters.-->
+    <select idref="xccdf_org.ssgproject.content_rule_wireless_disable_interfaces" selected="true"/>
+    <!--UBTU-22-232015 The Ubuntu operating system must have system commands set to a mode of 0755 or less permissive.-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_binary_dirs" selected="true"/>
+    <!--UBTU-22-232050 The Ubuntu operating system must have system commands owned by root.-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_ownership_binary_dirs" selected="true"/>
+    <!--UBTU-22-232055 The Ubuntu operating system must have system commands group-owned by root.-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupownership_system_commands_dirs" selected="true"/>
+    <!--UBTU-22-271030 The Ubuntu operating system must disable the x86 Ctrl-Alt-Delete key sequence if a graphical user interface is installed.-->
+    <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_disable_ctrlaltdel_reboot" selected="true"/>
+    <!--UBTU-22-211015 The Ubuntu operating system must disable the x86 Ctrl-Alt-Delete key sequence.-->
+    <select idref="xccdf_org.ssgproject.content_rule_disable_ctrlaltdel_reboot" selected="true"/>
+    <!--UBTU-22-291010 The Ubuntu operating system must disable automatic mounting of Universal Serial Bus (USB) mass storage driver.-->
+    <select idref="xccdf_org.ssgproject.content_rule_kernel_module_usb-storage_disabled" selected="true"/>
+    <!--UBTU-22-611065 The Ubuntu operating system must not have accounts configured with blank or null passwords.-->
     <select idref="xccdf_org.ssgproject.content_rule_no_empty_passwords_etc_shadow" selected="true"/>
-    <!--6.2.3 Ensure all groups in /etc/passwd exist in /etc/group (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_gid_passwd_group_same" selected="true"/>
-    <!--6.2.4 Ensure shadow group is empty (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_ensure_shadow_group_empty" selected="true"/>
-    <!--6.2.5 Ensure no duplicate UIDs exist (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_account_unique_id" selected="true"/>
-    <!--6.2.6 Ensure no duplicate GIDs exist (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_group_unique_id" selected="true"/>
-    <!--6.2.7 Ensure no duplicate user names exist (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_account_unique_name" selected="true"/>
-    <!--6.2.8 Ensure no duplicate group names exist (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_group_unique_name" selected="true"/>
-    <!--6.2.9 Ensure root PATH Integrity (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_root_path_dirs_no_write" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_root_path_no_dot" selected="true"/>
-    <!--6.2.10 Ensure root is the only UID 0 account (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_no_uid_except_zero" selected="true"/>
-    <!--6.2.11 Ensure local interactive user home directories exist (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_interactive_home_directory_exists" selected="true"/>
-    <!--6.2.12 Ensure local interactive users own their home directories (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_ownership_home_directories" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupownership_home_directories" selected="true"/>
-    <!--6.2.13 Ensure users' home directories permissions are 750 or more restrictive (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_home_directories" selected="true"/>
-    <!--6.2.14 Ensure no local interactive user has .netrc files (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_no_netrc_files" selected="true"/>
-    <!--6.2.16 Ensure no users have .rhosts files (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_no_rsh_trust_files" selected="true"/>
-    <!--6.2.17 Ensure local interactive user dot files are not group or world writable (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_no_world_writable_programs" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_group_ownership" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_user_ownership" selected="true"/>
+    <!--UBTU-22-611060 The Ubuntu operating system must not allow accounts configured with blank or null passwords.-->
+    <select idref="xccdf_org.ssgproject.content_rule_no_empty_passwords" selected="true"/>
+    <!--UBTU-22-271025 must initiate a graphical session lock after 15 minutes of inactivity-->
+    <set-value idref="xccdf_org.ssgproject.content_value_inactivity_timeout_value">900</set-value>
+    <set-value idref="xccdf_org.ssgproject.content_value_var_screensaver_lock_delay">0</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_screensaver_lock_delay" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_screensaver_idle_delay" selected="true"/>
+    <!--UBTU-22-654220 The Ubuntu operating system must generate audit records when successful/unsuccessful attempts to modify the /etc/sudoers file occur-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_sudoers" selected="true"/>
+    <!--UBTU-22-654225 The Ubuntu operating system must generate audit records when successful/unsuccessful attempts to modify the /etc/sudoers.d directory occur-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_sudoers_d" selected="true"/>
+    <!--UBTU-22-611055 The Ubuntu operating system must store only encrypted representations of passwords-->
+    <select idref="xccdf_org.ssgproject.content_rule_set_password_hashing_algorithm_systemauth" selected="true"/>
+    <!--UBTU-22-654190 The Ubuntu operating system must generate audit records for all events that affect the systemd journal files-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_var_log_journal" selected="true"/>
+    <!--UBTU-22-215020 The Ubuntu operating system must not have the "systemd-timesyncd" package installed-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_timesyncd_removed" selected="true"/>
+    <!--UBTU-22-215025 The Ubuntu operating system must not have the "ntp" package installed-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_ntp_removed" selected="true"/>
+    <!--UBTU-22-232027 The Ubuntu operating system must generate system journal entries without revealing information that could be exploited by adversaries-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_system_journal" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_dir_permissions_system_journal" selected="true"/>
+    <!--UBTU-22-232080 The Ubuntu operating system must configure the directories used by the system journal to be owned by "root"-->
+    <select idref="xccdf_org.ssgproject.content_rule_dir_owner_system_journal" selected="true"/>
+    <!--UBTU-22-232085 The Ubuntu operating system must configure the directories used by the system journal to be group-owned by "systemd-journal"-->
+    <select idref="xccdf_org.ssgproject.content_rule_dir_groupowner_system_journal" selected="true"/>
+    <!--UBTU-22-232090 The Ubuntu operating system must configure the files used by the system journal to be owned by "root"-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_system_journal" selected="true"/>
+    <!--UBTU-22-232095 The Ubuntu operating system must configure the files used by the system journal to be group-owned by "systemd-journal"-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_system_journal" selected="true"/>
+    <!--UBTU-22-232100 The Ubuntu operating system must be configured so that the "journalctl" command is owned by "root"-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_journalctl" selected="true"/>
+    <!--UBTU-22-232105 The Ubuntu operating system must be configured so that the "journalctl" command is group-owned by "root"-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_journalctl" selected="true"/>
+    <!--UBTU-22-232140 The Ubuntu operating system must be configured so that the "journalctl" command is not accessible by unauthorized users-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_journalctl" selected="true"/>
   </Profile>
 </Tailoring>

--- a/container/usg-audit.sh
+++ b/container/usg-audit.sh
@@ -29,12 +29,12 @@ echo "installing bs4"
 # Install the python library BeautifulSoup to parse html
 python3 -m pip install beautifulsoup4
 
-# Run cis audit and put html results into cis-audit.html file
+# Run stig audit and put html results into stig-audit.html file
 echo "running audit"
 usg audit --tailoring-file common-pipelines/container/tailor.xml --html-file $PWD/audit/$IMAGENAME-audit.html --results-file $PWD/audit/$IMAGENAME-audit.xml
 
 # Parse the resulting cis-audit.html file looking for pass/fail via a python script
-if [ "$(./common-pipelines/container/parse_cis_audit_html.py --inputfile audit/$IMAGENAME-audit.html)" == "failed" ]
+if [ "$(./common-pipelines/container/parse_stig_audit_html.py --inputfile audit/$IMAGENAME-audit.html)" == "failed" ]
 then
   echo "Container hardening audit FAILED"
   exit 1


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update usg audit command to use the disa stig tailoring file
- Update code to remove reference to cis benchmarks

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Updating to use disa stig
