### PR TITLE
update registry-image-resource to use our own Dockerfile

### DIFF
--- a/ci/container/external/registry-image-resource/vars.yml
+++ b/ci/container/external/registry-image-resource/vars.yml
@@ -1,9 +1,9 @@
 image-repository: registry-image-resource
-# oci-build-params:
-#   DOCKERFILE: common-dockerfiles/container/dockerfiles/registry-image-resource/Dockerfile
+oci-build-params:
+  DOCKERFILE: common-dockerfiles/container/dockerfiles/registry-image-resource/Dockerfile
 src-source:
   uri: https://github.com/concourse/registry-image-resource
   branch: master
   # Since src is a repo outside the cloud-gov org, don't verify commits.
-# dockerfile-path: ["container/dockerfiles/registry-image-resource/Dockerfile"]
-# dockerfile-trigger: true
+dockerfile-path: ["container/dockerfiles/registry-image-resource/Dockerfile"]
+dockerfile-trigger: true

--- a/container/dockerfiles/registry-image-resource/Dockerfile
+++ b/container/dockerfiles/registry-image-resource/Dockerfile
@@ -9,8 +9,7 @@ COPY go.sum .
 RUN go mod download
 
 COPY . .
-ENV CGO_ENABLED=0
-ENV AWS_USE_FIPS_ENDPOINT=true
+ENV CGO_ENABLED 0
 RUN go build -o /assets/in ./cmd/in
 RUN go build -o /assets/out ./cmd/out
 RUN go build -o /assets/check ./cmd/check
@@ -21,7 +20,6 @@ RUN set -e; for pkg in $(go list ./...); do \
 FROM ${base_image} AS resource
 USER root
 ENV DEBIAN_FRONTEND=noninteractive
-ENV AWS_USE_FIPS_ENDPOINT=true
 RUN apt update && apt upgrade -y -o Dpkg::Options::="--force-confdef"
 RUN apt update \
   && apt install -y --no-install-recommends \
@@ -42,12 +40,8 @@ ARG DOCKER_PRIVATE_REPO
 ARG DOCKER_PUSH_USERNAME
 ARG DOCKER_PUSH_PASSWORD
 ARG DOCKER_PUSH_REPO
-ARG GCR_PUSH_SERVICE_ACCOUNT_KEY
-ARG GCR_PUSH_REPO
-ENV AWS_USE_FIPS_ENDPOINT=true
 RUN set -e; for test in /tests/*.test; do \
   $test -ginkgo.v; \
   done
 
 FROM resource
-ENV AWS_USE_FIPS_ENDPOINT=true


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updates the registry-image-resource to use our own Dockerfile

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Upstream Dockerfile is no longer compatible with our base hardened image
