### PR TITLE
Adds a hardened-stack internal pipelines

### DIFF
--- a/ci/container/internal/hardened-stack/vars.yml
+++ b/ci/container/internal/hardened-stack/vars.yml
@@ -1,0 +1,4 @@
+base-image: cflinuxfs4
+base-image-tag: "1.268"
+image-repository: cloudfoundry
+src-repo: cloud-gov/ubuntu-hardened

--- a/ci/container/pipeline.yml
+++ b/ci/container/pipeline.yml
@@ -27,6 +27,7 @@ jobs:
               - general-task
               - github-pr-resource
               - github-release-resource
+              - hardened-stack
               - legacy-domain-certificate-renewer-testing
               - oci-build-task
               - opensearch-dashboards-testing


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds a hardened-stack internal pipeline based on the https://github.com/cloud-gov/ubuntu-hardened repo. 
- The base image is the cloudfoundry/cflinuxfs4 image. This is the current stack running in CloudFoundry. 

## Security considerations

Centralizes security hardening in the https://github.com/cloud-gov/ubuntu-hardened. 
