### PR TITLE
use our own dockerfiles for resources

### DIFF
--- a/ci/container/external/pool-resource/vars.yml
+++ b/ci/container/external/pool-resource/vars.yml
@@ -1,5 +1,9 @@
 image-repository: pool-resource
+oci-build-params:
+  DOCKERFILE: common-dockerfiles/container/dockerfiles/pool-resource/Dockerfile
 src-source:
   uri: https://github.com/concourse/pool-resource
   branch: master
   # Since src is a repo outside the cloud-gov org, don't verify commits.
+dockerfile-path: ["container/dockerfiles/pool-resource/Dockerfile"]
+dockerfile-trigger: true

--- a/ci/container/external/time-resource/vars.yml
+++ b/ci/container/external/time-resource/vars.yml
@@ -1,5 +1,9 @@
 image-repository: time-resource
+oci-build-params:
+  DOCKERFILE: common-dockerfiles/container/dockerfiles/time-resource/Dockerfile
 src-source:
   uri: https://github.com/concourse/time-resource
   branch: master
   # Since src is a repo outside the cloud-gov org, don't verify commits.
+dockerfile-path: ["container/dockerfiles/time-resource/Dockerfile"]
+dockerfile-trigger: true

--- a/container/dockerfiles/pool-resource/Dockerfile
+++ b/container/dockerfiles/pool-resource/Dockerfile
@@ -1,0 +1,47 @@
+ARG base_image
+ARG builder_image=golang
+
+FROM ${builder_image} as builder
+WORKDIR /src
+COPY . .
+RUN go mod download
+RUN go build -o /assets/out github.com/concourse/pool-resource/cmd/out
+RUN set -e; for pkg in $(go list ./...); do \
+    go test -o "/tests/$(basename $pkg).test" -c $pkg; \
+    done
+
+FROM ${base_image} AS resource
+USER root
+RUN apt update && apt upgrade -y -o Dpkg::Options::="--force-confdef"
+RUN apt update && apt install -y jq git make g++ libssl-dev openssh-client
+RUN git config --global user.email "git@localhost"
+RUN git config --global user.name "git"
+
+ADD assets/ /opt/resource/
+RUN chmod +x /opt/resource/*
+COPY --from=builder /assets /opt/go
+RUN chmod +x /opt/go/out
+
+WORKDIR /root
+RUN git clone https://github.com/proxytunnel/proxytunnel.git && \
+    cd proxytunnel && \
+    make -j4 && \
+    install -c proxytunnel /usr/bin/proxytunnel && \
+    cd .. && \
+    rm -rf proxytunnel
+
+FROM resource AS tests
+COPY --from=builder /tests /go/resource-tests/
+RUN set -e; for test in /go/resource-tests/*.test; do \
+    $test; \
+    done
+ADD test/ /opt/resource-tests
+RUN /opt/resource-tests/all.sh
+
+FROM resource AS integrationtests
+RUN apt update && apt install -y squid net-tools
+ADD test/ /opt/resource-tests/test
+ADD integration-tests /opt/resource-tests/integration-tests
+RUN /opt/resource-tests/integration-tests/integration.sh
+
+FROM resource

--- a/container/dockerfiles/time-resource/Dockerfile
+++ b/container/dockerfiles/time-resource/Dockerfile
@@ -1,0 +1,28 @@
+ARG base_image
+ARG builder_image=golang
+
+FROM ${builder_image} AS builder
+WORKDIR /concourse/time-resource
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+COPY . /concourse/time-resource
+ENV CGO_ENABLED 0
+RUN go build -o /assets/out github.com/concourse/time-resource/out
+RUN go build -o /assets/in github.com/concourse/time-resource/in
+RUN go build -o /assets/check github.com/concourse/time-resource/check
+RUN set -e; for pkg in $(go list ./...); do \
+    go test -o "/tests/$(basename $pkg).test" -c $pkg; \
+    done
+
+FROM ${base_image} AS resource
+USER root
+COPY --from=builder /assets /opt/resource
+
+FROM resource AS tests
+COPY --from=builder /tests /tests
+RUN set -e; for test in /tests/*.test; do \
+    $test; \
+    done
+
+FROM resource


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update pool-resource and time-resource to use our own version of the Dockerfile since upstream switched to wolfi

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Updating pipelines to use our own dockerfiles
