### PR TITLE
use build secrets rather than build args for token

### DIFF
--- a/container/oci-build.yml
+++ b/container/oci-build.yml
@@ -11,16 +11,16 @@ image_resource:
     tag: latest
 
 caches:
-- path: cache
+  - path: cache
 
 inputs:
-- name: src
-- name: base-image
-- name: common-pipelines
-- name: common-dockerfiles
+  - name: src
+  - name: base-image
+  - name: common-pipelines
+  - name: common-dockerfiles
 
 outputs:
-- name: image
+  - name: image
 
 run:
   path: build
@@ -31,7 +31,7 @@ params:
   # Match the base image build ARG to the image reference set in IMAGE_ARG_base_image.
   # BUILD_ARG_base_image: base-image
   # Required for running 'usg' hardening tool.
-  BUILD_ARG_TOKEN: ((ubuntu-advantage-token))
+  BUILDKIT_SECRETTEXT_TOKEN: ((ubuntu-advantage-token))
   # Required to use the image in later steps.
   UNPACK_ROOTFS: true
   # Set build context to the repository containing the dockerfile.


### PR DESCRIPTION
## Changes proposed in this pull request:

- Use build secrets rather than args for token

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Build secrets are a more secure method than args
