### PR TITLE
update cflinuxfs4 candidate image to use disa stigs

### DIFF
--- a/ci/container/internal/cflinuxfs4-hardened-candidate/vars.yml
+++ b/ci/container/internal/cflinuxfs4-hardened-candidate/vars.yml
@@ -2,3 +2,5 @@ base-image: cloudfoundry-cflinuxfs4
 base-image-tag: "1.268.0"
 image-repository: cflinuxfs4-hardened-candidate
 src-repo: cloud-gov/ubuntu-hardened
+src-branch: disa-stig
+tailoring-file: common-pipelines/container/tailor-stig.xml


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update the cflinuxfs4 candidate image to use disa stigs

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Switching to disa stig from cis
