### PR TITLE
fix file permissions

### DIFF
--- a/container/usg-audit.sh
+++ b/container/usg-audit.sh
@@ -29,6 +29,9 @@ echo "installing bs4"
 # Install the python library BeautifulSoup to parse html
 python3 -m pip install beautifulsoup4
 
+#fix file permissions after running apt so audit passes properly
+find /var/log -perm /137 ! -name '*[bw]tmp' ! -name '*lastlog' -type f -exec chmod 640 '{}' \;
+
 # Run audit and put html results into audit.html file
 echo "running audit"
 usg audit --tailoring-file $TAILORINGFILE --html-file $PWD/audit/$IMAGENAME-audit.html --results-file $PWD/audit/$IMAGENAME-audit.xml


### PR DESCRIPTION
## Changes proposed in this pull request:

- When we run apt to install the necessary tools to run the audit it changes file permissions. This adds a line to change them back so the audit passes

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Fixing file permissions
