### PR TITLE
remove dockerfile triggers

### DIFF
--- a/ci/container/internal/playwright-python/vars.yml
+++ b/ci/container/internal/playwright-python/vars.yml
@@ -1,4 +1,3 @@
 image-repository: playwright-python
 src-repo: cloud-gov/playwright-python
 src-target-branch: main
-dockerfile-trigger: true

--- a/ci/container/pages/base_vars.yml
+++ b/ci/container/pages/base_vars.yml
@@ -3,5 +3,5 @@ base-image-tag: latest
 src-target-branch: main
 common-pipelines-trigger: false
 dockerfile-path: []
-dockerfile-trigger: true
+dockerfile-trigger: false
 tailoring-file: common-pipelines/container/tailor.xml

--- a/ci/container/pages/base_vars.yml
+++ b/ci/container/pages/base_vars.yml
@@ -1,6 +1,7 @@
 base-image: ubuntu-hardened
 base-image-tag: latest
 src-target-branch: main
+src-path: []
 common-pipelines-trigger: false
 dockerfile-path: []
 dockerfile-trigger: false

--- a/ci/container/pages/dind/vars.yml
+++ b/ci/container/pages/dind/vars.yml
@@ -1,3 +1,4 @@
 image-repository: pages-dind
 oci-build-params: { CONTEXT: src/dind/v27 }
 src-repo: cloud-gov/pages-images
+src-path: [dind/v27/*]

--- a/ci/container/pages/nginx-v1/vars.yml
+++ b/ci/container/pages/nginx-v1/vars.yml
@@ -1,3 +1,4 @@
 image-repository: pages-nginx-v1
 oci-build-params: { CONTEXT: src/nginx/v1 }
 src-repo: cloud-gov/pages-images
+src-path: [nginx/v1/*]

--- a/ci/container/pages/node-v20/vars.yml
+++ b/ci/container/pages/node-v20/vars.yml
@@ -1,3 +1,4 @@
 image-repository: pages-node-v20
 oci-build-params: { CONTEXT: src/node/v20 }
 src-repo: cloud-gov/pages-images
+src-path: [node/v20/*]

--- a/ci/container/pages/postgres-v15/vars.yml
+++ b/ci/container/pages/postgres-v15/vars.yml
@@ -1,3 +1,4 @@
 image-repository: pages-postgres-v15
 oci-build-params: { CONTEXT: src/postgres/v15 }
 src-repo: cloud-gov/pages-images
+src-path: [postgres/v15/*]

--- a/ci/container/pages/python-v3.11/vars.yml
+++ b/ci/container/pages/python-v3.11/vars.yml
@@ -1,3 +1,4 @@
 image-repository: pages-python-v3.11
 oci-build-params: { CONTEXT: src/python/v3.11 }
 src-repo: cloud-gov/pages-images
+src-path: [python/v3.11/*]

--- a/ci/container/pages/redis-v7.2/vars.yml
+++ b/ci/container/pages/redis-v7.2/vars.yml
@@ -1,3 +1,4 @@
 image-repository: pages-redis-v7.2
 oci-build-params: { CONTEXT: src/redis/v7.2 }
 src-repo: cloud-gov/pages-images
+src-path: [redis/v7.2/*]

--- a/ci/container/pages/zap/vars.yml
+++ b/ci/container/pages/zap/vars.yml
@@ -1,3 +1,4 @@
 image-repository: pages-zap
 oci-build-params: { CONTEXT: src/zap }
 src-repo: cloud-gov/pages-images
+src-path: [zap/*]

--- a/container/pipeline-pages.yml
+++ b/container/pipeline-pages.yml
@@ -276,6 +276,7 @@ resources:
       uri: https://github.com/((src-repo))
       branch: ((src-target-branch))
       commit_verification_keys: ((cloud-gov-pages-gpg-keys))
+      paths: ((src-path))
 
   - name: pull-request
     type: pull-request


### PR DESCRIPTION
## Changes proposed in this pull request:

- Removes the dockerfile trigger for playwright-python since it is not needed
- Sets the dockerfile trigger to false in the pages base_vars.yml file since we also do not need this trigger for pages pipelines. The dockerfile trigger is only necessary if we have set up our own dockerfile for a repo in common-pipelines
- Adds a src-path check for the pages repo, so it only triggers when the src for the relevant pages image is updated
- These changes should help with the issue of disappearing resources

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Gets rid of unnecessary triggers to help with the issue of disappearing resources
