### PR TITLE
add stig build job

### DIFF
--- a/ci/container/internal/base_vars.yml
+++ b/ci/container/internal/base_vars.yml
@@ -1,5 +1,7 @@
 base-image: ubuntu-hardened
 base-image-tag: latest
+stig-base-image: ubuntu-hardened-stig
+stig-base-image-tag: latest
 oci-build-params: {}
 common-pipelines-trigger: false
 dockerfile-path: []

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -274,6 +274,41 @@ jobs:
           <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
         channel: ((slack-channel-success))
 
+  - name: test-stig-build
+    serial_groups: [container-scans]
+    plan:
+      - in_parallel:
+          - get: src
+            trigger: true
+
+          - get: stig-base-image
+            trigger: true
+            params:
+              format: oci
+
+          - get: common-pipelines
+            trigger: ((common-pipelines-trigger))
+
+          - get: common-dockerfiles
+            trigger: ((dockerfile-trigger))
+
+      - task: oci-build
+        privileged: true
+        file: common-pipelines/container/oci-build.yml
+        params: ((oci-build-params)) # for available params, see https://github.com/concourse/oci-build-task#params
+
+      - in_parallel:
+          - task: clamav-scan
+            file: common-pipelines/container/clamav-scan.yml
+            image: image
+
+          - task: usg-audit
+            file: common-pipelines/container/usg-audit.yml
+            image: image
+            params:
+              IMAGENAME: ((image-repository))-stig
+              TAILORINGFILE: common-pipelines/container/tailor-stig.xml
+
 resources:
   - name: base-image
     type: registry-image
@@ -282,6 +317,15 @@ resources:
       aws_secret_access_key: ((ecr_aws_secret))
       repository: ((base-image))
       tag: ((base-image-tag))
+      aws_region: us-gov-west-1
+
+  - name: stig-base-image
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: ((stig-base-image))
+      tag: ((stig-base-image-tag))
       aws_region: us-gov-west-1
 
   - name: common-pipelines


### PR DESCRIPTION
## Changes proposed in this pull request:

- Creates a job to test building the container images for our internal repos using disa stigs rather than cis benchmarks
- Having a separate job means it won't effect our normal container build workstream, and won't trigger alerts.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Testing disa stigs
