### PR TITLE
remove old refs to base images

### DIFF
--- a/ci/container/pipeline.yml
+++ b/ci/container/pipeline.yml
@@ -58,8 +58,6 @@ jobs:
               - s3-resource
               - s3-simple-resource
               - slack-notification-resource
-              - ubuntu-hardened
-              - ubuntu-hardened-stig
 
         do:
           - set_pipeline: ((.:name))


### PR DESCRIPTION
## Changes proposed in this pull request:

- Remove references to ubuntu-hardened images from the internal-pipelines job now that they've been moved to the base-pipeline job

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just removing unneeded references