### PR TITLE
added support for internal repo

### DIFF
--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -330,6 +330,14 @@ resources:
       uri: https://github.com/((src-repo))
       branch: ((src-branch))
       commit_verification_keys: ((cloud-gov-pgp-keys))
+      git_config:
+        - name: user.name
+          value: cg-ci-bot
+        - name: user.email
+          value: no-reply@cloud.gov
+
+      private_key: ((cg-ci-bot-sshkey.private_key))
+      username: cg-ci-bot
 
   - name: daily
     type: time


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updated to allow pipeline to access private repo for deployment
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the output, which can prevent unintentional leaks of sensitive data.

## Security considerations

Verified with platform this is the best method to resolve this, so none.