### PR TITLE
add input mapping

### DIFF
--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -275,6 +275,8 @@ jobs:
             trigger: ((dockerfile-trigger))
 
       - task: oci-build
+        input_mapping:
+          base-image: stig-base-image
         privileged: true
         file: common-pipelines/container/oci-build.yml
         params: ((oci-build-params)) # for available params, see https://github.com/concourse/oci-build-task#params


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds input mapping so oci-build-task in the stig test job doesn't break

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, fixing broken task
