### PR TITLE
add clamav-rest image for malware scanning

### DIFF
--- a/ci/container/internal/clamav-rest/vars.yml
+++ b/ci/container/internal/clamav-rest/vars.yml
@@ -1,0 +1,9 @@
+base-image: ubuntu-hardened-stig
+image-repository: clamav-rest
+oci-build-params:
+  BUILD_ARGS_FILE: clamav-rest-image/image/args/build-args.yml
+  DOCKERFILE: clamav-rest-image/image/Dockerfile
+src-repo: cloud-gov/clamav-rest-image
+src-branch: develop
+dockerfile-path: ["image/Dockerfile"]
+dockerfile-trigger: true

--- a/ci/container/pipeline.yml
+++ b/ci/container/pipeline.yml
@@ -40,6 +40,7 @@ jobs:
               - cf-resource
               - cflinuxfs4-hardened-candidate
               - cg-csb
+              - clamav-rest
               - concourse-http-jq-resource
               - cron-resource
               - csb-helper


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds a pipeline to build the clamav-rest image on ubuntu (used in malware scanning for Pages uploads)


## Security considerations

Malware scanning is good. Ports the clamav-rest to our ubuntu image.
