### PR TITLE
incorrect dockerfile location

### DIFF
--- a/ci/container/internal/clamav-rest/vars.yml
+++ b/ci/container/internal/clamav-rest/vars.yml
@@ -5,5 +5,3 @@ oci-build-params:
   DOCKERFILE: src/image/Dockerfile
 src-repo: cloud-gov/clamav-rest-image
 src-branch: develop
-dockerfile-path: ["image/Dockerfile"]
-dockerfile-trigger: true


### PR DESCRIPTION
## Changes proposed in this pull request:

- The dockerfile-* properties are for those dockerfiles stored in common-pipelines. 


## Security considerations

None
