### PR TITLE
context  doesn't apply to build args file path

### DIFF
--- a/ci/container/internal/clamav-rest/vars.yml
+++ b/ci/container/internal/clamav-rest/vars.yml
@@ -1,7 +1,7 @@
 base-image: ubuntu-hardened-stig
 image-repository: clamav-rest
 oci-build-params:
-  BUILD_ARGS_FILE: args/build-args.conf
+  BUILD_ARGS_FILE: src/image/args/build-args.conf
   CONTEXT: src/image
 src-repo: cloud-gov/clamav-rest-image
 src-branch: develop


### PR DESCRIPTION
## Changes proposed in this pull request:

- Sets the build args file path relative to the concourse build, not the oci build context. 

## Security considerations

None
