### PR TITLE
use the stig tailoring file as the main job uses the stig image

### DIFF
--- a/ci/container/internal/clamav-rest/vars.yml
+++ b/ci/container/internal/clamav-rest/vars.yml
@@ -5,3 +5,4 @@ oci-build-params:
   CONTEXT: src/image
 src-repo: cloud-gov/clamav-rest-image
 src-branch: develop
+tailoring-file: common-pipelines/container/tailor-stig.xml


### PR DESCRIPTION
## Changes proposed in this pull request:

- Stig tailoring file for usg audits. We are using the stig base image. 

## Security considerations

Tailoring file needs to match the image. 
