### PR TITLE
update semver resource

### DIFF
--- a/ci/container/external/semver-resource/vars.yml
+++ b/ci/container/external/semver-resource/vars.yml
@@ -2,8 +2,8 @@ image-repository: semver-resource
 oci-build-params:
   DOCKERFILE: common-dockerfiles/container/dockerfiles/semver-resource/Dockerfile
 src-source:
-  uri: https://github.com/alphagov/paas-semver-resource
-  branch: gds_main
+  uri: https://github.com/concourse/semver-resource
+  branch: master
   # Since src is a repo outside the cloud-gov org, don't verify commits.
 dockerfile-path: ["container/dockerfiles/semver-resource/Dockerfile"]
 dockerfile-trigger: true

--- a/container/dockerfiles/semver-resource/Dockerfile
+++ b/container/dockerfiles/semver-resource/Dockerfile
@@ -1,30 +1,48 @@
-# Dockerfile using our hardened base image
 ARG base_image
-FROM golang:1.14 as builder
+ARG builder_image=concourse/golang-builder
 
-ENV CONCOURSE_CODE_PATH ${GOPATH}/src/github.com/concourse/semver-resource
+FROM ${builder_image} AS builder
 
-RUN apt update && apt upgrade -y -o Dpkg::Options::="--force-confdef"
-RUN apt install -y --no-install-recommends \
-    git \
-    bash 
-
-ADD . /code
-
-RUN mkdir -p $(dirname ${CONCOURSE_CODE_PATH}) \
-    && ln -s /code ${CONCOURSE_CODE_PATH}
-
-RUN cd ${CONCOURSE_CODE_PATH} \
-  && go get -v -d ./...
-
-RUN cd ${CONCOURSE_CODE_PATH} \
-  && ./scripts/build
-
-RUN cd ${CONCOURSE_CODE_PATH} \
-  && mkdir -p /opt/resource \
-  && cp assets/* /opt/resource
-
-RUN rm -rf ${GOPATH} ${GOROOT} /usr/local/go /code
+COPY . /src
+WORKDIR /src
+ENV CGO_ENABLED=0
+RUN go mod download
+RUN go build -o /assets/in ./in
+RUN go build -o /assets/out ./out
+RUN go build -o /assets/check ./check
+RUN set -e; for pkg in $(go list ./...); do \
+  go test -o "/tests/$(basename $pkg).test" -c $pkg; \
+  done
 
 FROM ${base_image} AS resource
-COPY --from=builder /opt/resource /opt/resource
+RUN apt update && apt upgrade -y -o Dpkg::Options::="--force-confdef"
+RUN apt update && apt install -y --no-install-recommends \
+  tzdata \
+  ca-certificates \
+  git \
+  jq \
+  openssh-client
+RUN git config --global user.email "git@localhost"
+RUN git config --global user.name "git"
+COPY --from=builder assets/ /opt/resource/
+RUN chmod +x /opt/resource/*
+
+FROM resource AS tests
+RUN apt update && apt install -y --no-install-recommends \
+  bash \
+  openssh-client
+ARG SEMVER_TESTING_ACCESS_KEY_ID
+ARG SEMVER_TESTING_SECRET_ACCESS_KEY
+ARG SEMVER_TESTING_BUCKET
+ARG SEMVER_TESTING_REGION
+ARG SEMVER_TESTING_V2_SIGNING
+COPY --from=builder /tests /go-tests
+WORKDIR /go-tests
+RUN set -e; for test in /go-tests/*.test; do \
+  $test; \
+  done
+COPY test/ /opt/resource-tests
+RUN /opt/resource-tests/all.sh
+
+
+FROM resource


### PR DESCRIPTION
## Changes proposed in this pull request:

- This switches the semver github resource to the official concourse resource
- This also updates official the Dockerfile to incorporate the changes from the official concourse resource while still using our base ubuntu image
- This shouldn't affect any current pipelines, as only a couple of them reference the resource, but they don't actually get used

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Updating the semver resource
