### PR TITLE
the image is a candidate as it has not passed testing yet

### DIFF
--- a/ci/container/internal/clamav-rest-candidate/vars.yml
+++ b/ci/container/internal/clamav-rest-candidate/vars.yml
@@ -1,5 +1,5 @@
 base-image: ubuntu-hardened-stig
-image-repository: clamav-rest
+image-repository: clamav-rest-candidate
 oci-build-params:
   BUILD_ARGS_FILE: src/image/args/build-args.conf
   CONTEXT: src/image

--- a/ci/container/pipeline.yml
+++ b/ci/container/pipeline.yml
@@ -40,7 +40,7 @@ jobs:
               - cf-resource
               - cflinuxfs4-hardened-candidate
               - cg-csb
-              - clamav-rest
+              - clamav-rest-candidate
               - concourse-http-jq-resource
               - cron-resource
               - csb-helper


### PR DESCRIPTION
## Changes proposed in this pull request:

- Renames the image pipeline to reflect the "candidate" status. 
- The released image will be uploaded by a different pipeline after the candidate passes tests.

I will remove the existing pipeline manually once merged. 


## Security considerations

None
