### PR TITLE
adds build-test task

### DIFF
--- a/ci/container/external/base_vars.yml
+++ b/ci/container/external/base_vars.yml
@@ -7,3 +7,9 @@ common-pipelines-trigger: false
 dockerfile-path: []
 dockerfile-trigger: false
 tailoring-file: common-pipelines/container/tailor.xml
+build-test-cmd: echo
+build-test-args:
+  [
+    "No build test command configured. Set build-test-cmd and build-test-args in your pipeline configuration file to run tests",
+  ]
+build-test-params: {}

--- a/ci/container/internal/base_vars.yml
+++ b/ci/container/internal/base_vars.yml
@@ -11,5 +11,11 @@ static-analysis-args:
   [
     "No static analysis command configured. Set static-analysis-cmd and static-analysis-args in your pipeline configuration file to run static analysis on your source code.",
   ]
+build-test-cmd: echo
+build-test-args:
+  [
+    "No build test command configured. Set build-test-cmd and build-test-args in your pipeline configuration file to run tests",
+  ]
+build-test-params: {}
 src-branch: main
 tailoring-file: common-pipelines/container/tailor.xml

--- a/ci/container/internal/cf-resource/vars.yml
+++ b/ci/container/internal/cf-resource/vars.yml
@@ -2,3 +2,10 @@ image-repository: cf-resource
 oci-build-params: { DOCKERFILE: src/dockerfiles/ubuntu/Dockerfile }
 src-repo: cloud-gov/cf-resource
 src-target-branch: master
+build-test-cmd: build
+build-test-args: []
+build-test-params:
+  DOCKERFILE: src/dockerfiles/ubuntu/Dockerfile
+  TARGET: tests
+  IMAGE_ARG_base_image: base-image/image.tar
+  CONTEXT: src

--- a/ci/container/pages/base_vars.yml
+++ b/ci/container/pages/base_vars.yml
@@ -8,3 +8,9 @@ common-pipelines-trigger: false
 dockerfile-path: []
 dockerfile-trigger: false
 tailoring-file: common-pipelines/container/tailor.xml
+build-test-cmd: echo
+build-test-args:
+  [
+    "No build test command configured. Set build-test-cmd and build-test-args in your pipeline configuration file to run tests",
+  ]
+build-test-params: {}

--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -196,6 +196,30 @@ jobs:
         file: common-pipelines/container/oci-build.yml
         params: ((oci-build-params)) # for available params, see https://github.com/concourse/oci-build-task#params
 
+      - task: build-test
+        input_mapping:
+          base-image: stig-base-image
+        privileged: true
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              aws_access_key_id: ((ecr_aws_key))
+              aws_secret_access_key: ((ecr_aws_secret))
+              repository: oci-build-task
+              aws_region: us-gov-west-1
+              tag: latest
+          inputs:
+            - name: src
+            - name: base-image
+            - name: common-pipelines
+            - name: common-dockerfiles
+          params: ((build-test-params))
+          run:
+            path: ((build-test-cmd))
+            args: ((build-test-args))
+
       - in_parallel:
           - task: clamav-scan
             file: common-pipelines/container/clamav-scan.yml

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -281,6 +281,30 @@ jobs:
         file: common-pipelines/container/oci-build.yml
         params: ((oci-build-params)) # for available params, see https://github.com/concourse/oci-build-task#params
 
+      - task: build-test
+        input_mapping:
+          base-image: stig-base-image
+        privileged: true
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              aws_access_key_id: ((ecr_aws_key))
+              aws_secret_access_key: ((ecr_aws_secret))
+              repository: oci-build-task
+              aws_region: us-gov-west-1
+              tag: latest
+          inputs:
+            - name: src
+            - name: base-image
+            - name: common-pipelines
+            - name: common-dockerfiles
+          params: ((build-test-params))
+          run:
+            path: ((build-test-cmd))
+            args: ((build-test-args))
+
       - in_parallel:
           - task: clamav-scan
             file: common-pipelines/container/clamav-scan.yml

--- a/container/pipeline-pages.yml
+++ b/container/pipeline-pages.yml
@@ -256,6 +256,30 @@ jobs:
         file: common-pipelines/container/oci-build.yml
         params: ((oci-build-params)) # for available params, see https://github.com/concourse/oci-build-task#params
 
+      - task: build-test
+        input_mapping:
+          base-image: stig-base-image
+        privileged: true
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              aws_access_key_id: ((ecr_aws_key))
+              aws_secret_access_key: ((ecr_aws_secret))
+              repository: oci-build-task
+              aws_region: us-gov-west-1
+              tag: latest
+          inputs:
+            - name: src
+            - name: base-image
+            - name: common-pipelines
+            - name: common-dockerfiles
+          params: ((build-test-params))
+          run:
+            path: ((build-test-cmd))
+            args: ((build-test-args))
+
       - in_parallel:
           - task: clamav-scan
             file: common-pipelines/container/clamav-scan.yml


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds a task for running image build tests to all pipelines that by default only runs an echo command
- Sets this task only in the stig testing job for now
- Sets up a test for the cf-resource

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Setting up task to be able to run tests for all our container images