### PR TITLE
remove stig-build job from serial group

### DIFF
--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -171,7 +171,6 @@ jobs:
           <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 
   - name: test-stig-build
-    serial_groups: [container-scans]
     plan:
       - in_parallel:
           - get: src

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -257,7 +257,6 @@ jobs:
           <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 
   - name: test-stig-build
-    serial_groups: [container-scans]
     plan:
       - in_parallel:
           - get: src

--- a/container/pipeline-pages.yml
+++ b/container/pipeline-pages.yml
@@ -232,7 +232,6 @@ jobs:
         icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 
   - name: test-stig-build
-    serial_groups: [container-scans]
     plan:
       - in_parallel:
           - get: src


### PR DESCRIPTION
## Changes proposed in this pull request:

- Remove serial_groups option from test-stig-build job so it doesn't keep our regular jobs from running

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, improves speed of moving updates to containers through the pipelines
