### PR TITLE
refactor how source repo URIs are defined 

### DIFF
--- a/ci/container/base/ubuntu-hardened-stig/vars.yml
+++ b/ci/container/base/ubuntu-hardened-stig/vars.yml
@@ -2,5 +2,6 @@ base-image: ubuntu
 base-image-tag: "22.04"
 image-repository: ubuntu-hardened-stig
 src-repo: cloud-gov/ubuntu-hardened
+src-repo-uri: https://github.com/cloud-gov/ubuntu-hardened
 src-branch: disa-stig
 tailoring-file: common-pipelines/container/tailor-stig.xml

--- a/ci/container/base/ubuntu-hardened/vars.yml
+++ b/ci/container/base/ubuntu-hardened/vars.yml
@@ -2,3 +2,4 @@ base-image: ubuntu
 base-image-tag: "22.04"
 image-repository: ubuntu-hardened
 src-repo: cloud-gov/ubuntu-hardened
+src-repo-uri: https://github.com/cloud-gov/ubuntu-hardened

--- a/ci/container/internal/bosh-deployment-resource/vars.yml
+++ b/ci/container/internal/bosh-deployment-resource/vars.yml
@@ -1,2 +1,3 @@
 image-repository: bosh-deployment-resource
 src-repo: cloud-gov/bosh-deployment-resource
+src-repo-uri: https://github.com/cloud-gov/bosh-deployment-resource

--- a/ci/container/internal/cf-resource/vars.yml
+++ b/ci/container/internal/cf-resource/vars.yml
@@ -1,6 +1,7 @@
 image-repository: cf-resource
 oci-build-params: { DOCKERFILE: src/dockerfiles/ubuntu/Dockerfile }
 src-repo: cloud-gov/cf-resource
+src-repo-uri: https://github.com/cloud-gov/cf-resource
 src-target-branch: master
 build-test-cmd: build
 build-test-args: []

--- a/ci/container/internal/cflinuxfs4-hardened-candidate/vars.yml
+++ b/ci/container/internal/cflinuxfs4-hardened-candidate/vars.yml
@@ -2,5 +2,6 @@ base-image: cloudfoundry-cflinuxfs4
 base-image-tag: "1.268.0"
 image-repository: cflinuxfs4-hardened-candidate
 src-repo: cloud-gov/ubuntu-hardened
+src-repo-uri: https://github.com/cloud-gov/ubuntu-hardened
 src-branch: disa-stig
 tailoring-file: common-pipelines/container/tailor-stig.xml

--- a/ci/container/internal/cg-csb/vars.yml
+++ b/ci/container/internal/cg-csb/vars.yml
@@ -5,6 +5,7 @@ oci-build-params:
   BUILD_ARG_BUILD_ENV: production
 slack-channel-failure: "#cg-customer-success"
 src-repo: cloud-gov/csb
+src-repo-uri: https://github.com/cloud-gov/csb
 src-branch: ses-topic
 static-analysis-cmd: sh
 # We skip check updates because trivy tries pulling an image from GHCR but

--- a/ci/container/internal/clamav-rest-candidate/vars.yml
+++ b/ci/container/internal/clamav-rest-candidate/vars.yml
@@ -4,5 +4,6 @@ oci-build-params:
   BUILD_ARGS_FILE: src/image/args/build-args.conf
   CONTEXT: src/image
 src-repo: cloud-gov/clamav-rest-image
+src-repo-uri: https://github.com/cloud-gov/clamav-rest-image
 src-branch: develop
 tailoring-file: common-pipelines/container/tailor-stig.xml

--- a/ci/container/internal/concourse-http-jq-resource/vars.yml
+++ b/ci/container/internal/concourse-http-jq-resource/vars.yml
@@ -1,2 +1,3 @@
 image-repository: concourse-http-jq-resource
 src-repo: cloud-gov/concourse-http-jq-resource
+src-repo-uri: https://github.com/cloud-gov/concourse-http-jq-resource

--- a/ci/container/internal/cron-resource/vars.yml
+++ b/ci/container/internal/cron-resource/vars.yml
@@ -1,2 +1,3 @@
 image-repository: cron-resource
 src-repo: cloud-gov/cron-resource
+src-repo-uri: https://github.com/cloud-gov/cron-resource

--- a/ci/container/internal/csb-helper/vars.yml
+++ b/ci/container/internal/csb-helper/vars.yml
@@ -1,6 +1,7 @@
 image-repository: csb-helper
 slack-channel-failure: "#cg-customer-success"
 src-repo: cloud-gov/csb
+src-repo-uri: https://github.com/cloud-gov/csb
 src-branch: brokerpak-topic
 oci-build-params:
   CONTEXT: "src/helper"

--- a/ci/container/internal/external-domain-broker-migrator-testing/vars.yml
+++ b/ci/container/internal/external-domain-broker-migrator-testing/vars.yml
@@ -1,4 +1,5 @@
 image-repository: external-domain-broker-migrator-testing
 oci-build-params: { DOCKERFILE: src/docker/Dockerfile.dev }
 src-repo: cloud-gov/external-domain-broker-migrator
+src-repo-uri: https://github.com/cloud-gov/external-domain-broker-migrator
 src-target-branch: main

--- a/ci/container/internal/external-domain-broker-testing/vars.yml
+++ b/ci/container/internal/external-domain-broker-testing/vars.yml
@@ -1,4 +1,5 @@
 image-repository: external-domain-broker-testing
 oci-build-params: { DOCKERFILE: src/docker/Dockerfile.dev }
 src-repo: cloud-gov/external-domain-broker
+src-repo-uri: https://github.com/cloud-gov/external-domain-broker
 src-target-branch: main

--- a/ci/container/internal/general-task/vars.yml
+++ b/ci/container/internal/general-task/vars.yml
@@ -1,2 +1,3 @@
 image-repository: general-task
 src-repo: cloud-gov/general-task
+src-repo-uri: https://github.com/cloud-gov/general-task

--- a/ci/container/internal/github-pr-resource/vars.yml
+++ b/ci/container/internal/github-pr-resource/vars.yml
@@ -1,2 +1,3 @@
 image-repository: github-pr-resource
 src-repo: cloud-gov/github-pr-resource
+src-repo-uri: https://github.com/cloud-gov/github-pr-resource

--- a/ci/container/internal/github-release-resource/vars.yml
+++ b/ci/container/internal/github-release-resource/vars.yml
@@ -1,2 +1,3 @@
 image-repository: github-release-resource
 src-repo: cloud-gov/github-release-resource
+src-repo-uri: https://github.com/cloud-gov/github-release-resource

--- a/ci/container/internal/legacy-domain-certificate-renewer-testing/vars.yml
+++ b/ci/container/internal/legacy-domain-certificate-renewer-testing/vars.yml
@@ -1,4 +1,5 @@
 image-repository: legacy-domain-certificate-renewer-testing
 oci-build-params: { DOCKERFILE: src/docker/Dockerfile.dev }
 src-repo: cloud-gov/legacy-domain-certificate-renewer
+src-repo-uri: https://github.com/cloud-gov/legacy-domain-certificate-renewer
 src-target-branch: main

--- a/ci/container/internal/oci-build-task/vars.yml
+++ b/ci/container/internal/oci-build-task/vars.yml
@@ -1,2 +1,3 @@
 image-repository: oci-build-task
 src-repo: cloud-gov/oci-build-task
+src-repo-uri: https://github.com/cloud-gov/oci-build-task

--- a/ci/container/internal/opensearch-dashboards-testing/vars.yml
+++ b/ci/container/internal/opensearch-dashboards-testing/vars.yml
@@ -1,4 +1,5 @@
 image-repository: opensearch-dashboards-testing
 oci-build-params: { DOCKERFILE: src/docker/opensearch_dashboards/dockerfile }
 src-repo: cloud-gov/opensearch-dashboards-cf-auth-proxy
+src-repo-uri: git@github.com:cloud-gov/opensearch-dashboards-cf-auth-proxy.git
 src-target-branch: main

--- a/ci/container/internal/opensearch-testing/vars.yml
+++ b/ci/container/internal/opensearch-testing/vars.yml
@@ -1,4 +1,5 @@
 image-repository: opensearch-testing
 oci-build-params: { DOCKERFILE: src/docker/opensearch/dockerfile }
 src-repo: cloud-gov/opensearch-dashboards-cf-auth-proxy
+src-repo-uri: git@github.com:cloud-gov/opensearch-dashboards-cf-auth-proxy.git
 src-target-branch: main

--- a/ci/container/internal/paketo-jammy-full-hardened-candidate/vars.yml
+++ b/ci/container/internal/paketo-jammy-full-hardened-candidate/vars.yml
@@ -1,5 +1,6 @@
 base-image: paketo-jammy-full
 image-repository: paketo-jammy-full-hardened-candidate
 src-repo: cloud-gov/ubuntu-hardened
+src-repo-uri: https://github.com/cloud-gov/ubuntu-hardened
 src-branch: disa-stig
 tailoring-file: common-pipelines/container/tailor-stig.xml

--- a/ci/container/internal/playwright-python/vars.yml
+++ b/ci/container/internal/playwright-python/vars.yml
@@ -1,3 +1,4 @@
 image-repository: playwright-python
 src-repo: cloud-gov/playwright-python
+src-repo-uri: https://github.com/cloud-gov/playwright-python
 src-target-branch: main

--- a/ci/container/internal/pulledpork/vars.yml
+++ b/ci/container/internal/pulledpork/vars.yml
@@ -1,3 +1,4 @@
 image-repository: pulledpork
 oci-build-params: { DOCKERFILE: src/ci/docker/pulledpork/Dockerfile }
-src-repo: cloud-gov/cg-snort-boshrelease
+src-repo: cg-snort-boshrelease
+src-repo-uri: https://github.com/cloud-gov/cg-snort-boshrelease

--- a/ci/container/internal/pulledpork/vars.yml
+++ b/ci/container/internal/pulledpork/vars.yml
@@ -1,4 +1,4 @@
 image-repository: pulledpork
 oci-build-params: { DOCKERFILE: src/ci/docker/pulledpork/Dockerfile }
-src-repo: cg-snort-boshrelease
+src-repo: cloud-gov/cg-snort-boshrelease
 src-repo-uri: https://github.com/cloud-gov/cg-snort-boshrelease

--- a/ci/container/internal/s3-resource/vars.yml
+++ b/ci/container/internal/s3-resource/vars.yml
@@ -1,3 +1,4 @@
 image-repository: s3-resource
 oci-build-params: { DOCKERFILE: src/Dockerfile }
 src-repo: cloud-gov/s3-resource
+src-repo-uri: https://github.com/cloud-gov/s3-resource

--- a/ci/container/internal/s3-simple-resource/vars.yml
+++ b/ci/container/internal/s3-simple-resource/vars.yml
@@ -1,2 +1,3 @@
 image-repository: s3-simple-resource
 src-repo: cloud-gov/s3-simple-resource
+src-repo-uri: https://github.com/cloud-gov/s3-simple-resource

--- a/ci/container/internal/slack-notification-resource/vars.yml
+++ b/ci/container/internal/slack-notification-resource/vars.yml
@@ -1,3 +1,4 @@
 image-repository: slack-notification-resource
 oci-build-params: { DOCKERFILE: src/dockerfiles/ubuntu/Dockerfile }
 src-repo: cloud-gov/slack-notification-resource
+src-repo-uri: https://github.com/cloud-gov/slack-notification-resource

--- a/ci/container/internal/zap-runner/vars.yml
+++ b/ci/container/internal/zap-runner/vars.yml
@@ -1,4 +1,5 @@
 image-repository: zap-runner
 
 src-repo: cloud-gov/zap-runner
+src-repo-uri: https://github.com/cloud-gov/zap-runner
 src-target-branch: main

--- a/ci/container/pages/dind/vars.yml
+++ b/ci/container/pages/dind/vars.yml
@@ -1,4 +1,5 @@
 image-repository: pages-dind
 oci-build-params: { CONTEXT: src/dind/v27 }
 src-repo: cloud-gov/pages-images
+src-repo-uri: https://github.com/cloud-gov/pages-images
 src-path: [dind/v27/*]

--- a/ci/container/pages/nginx-v1/vars.yml
+++ b/ci/container/pages/nginx-v1/vars.yml
@@ -1,4 +1,5 @@
 image-repository: pages-nginx-v1
 oci-build-params: { CONTEXT: src/nginx/v1 }
 src-repo: cloud-gov/pages-images
+src-repo-uri: https://github.com/cloud-gov/pages-images
 src-path: [nginx/v1/*]

--- a/ci/container/pages/node-v20/vars.yml
+++ b/ci/container/pages/node-v20/vars.yml
@@ -1,4 +1,5 @@
 image-repository: pages-node-v20
 oci-build-params: { CONTEXT: src/node/v20 }
 src-repo: cloud-gov/pages-images
+src-repo-uri: https://github.com/cloud-gov/pages-images
 src-path: [node/v20/*]

--- a/ci/container/pages/postgres-v15/vars.yml
+++ b/ci/container/pages/postgres-v15/vars.yml
@@ -1,4 +1,5 @@
 image-repository: pages-postgres-v15
 oci-build-params: { CONTEXT: src/postgres/v15 }
 src-repo: cloud-gov/pages-images
+src-repo-uri: https://github.com/cloud-gov/pages-images
 src-path: [postgres/v15/*]

--- a/ci/container/pages/python-v3.11/vars.yml
+++ b/ci/container/pages/python-v3.11/vars.yml
@@ -1,4 +1,5 @@
 image-repository: pages-python-v3.11
 oci-build-params: { CONTEXT: src/python/v3.11 }
 src-repo: cloud-gov/pages-images
+src-repo-uri: https://github.com/cloud-gov/pages-images
 src-path: [python/v3.11/*]

--- a/ci/container/pages/redis-v7.2/vars.yml
+++ b/ci/container/pages/redis-v7.2/vars.yml
@@ -1,4 +1,5 @@
 image-repository: pages-redis-v7.2
 oci-build-params: { CONTEXT: src/redis/v7.2 }
 src-repo: cloud-gov/pages-images
+src-repo-uri: https://github.com/cloud-gov/pages-images
 src-path: [redis/v7.2/*]

--- a/ci/container/pages/zap/vars.yml
+++ b/ci/container/pages/zap/vars.yml
@@ -1,4 +1,5 @@
 image-repository: pages-zap
 oci-build-params: { CONTEXT: src/zap }
 src-repo: cloud-gov/pages-images
+src-repo-uri: https://github.com/cloud-gov/pages-images
 src-path: [zap/*]

--- a/container/examples/cloud-gov-repo/ci/vars.yml
+++ b/container/examples/cloud-gov-repo/ci/vars.yml
@@ -4,6 +4,7 @@ base-image-tag: "22.04"
 image-repository: cloud-gov-repo
 oci-build-params: {}
 src-repo: cloud-gov/ubuntu-hardened
+src-repo-uri: https://github.com/cloud-gov/ubuntu-hardened
 common-pipelines-trigger: false
 dockerfile-path: []
 dockerfile-trigger: false

--- a/container/examples/external-repo/ci/vars.yml
+++ b/container/examples/external-repo/ci/vars.yml
@@ -3,6 +3,7 @@ base-image-tag: "22.04"
 image-repository: external-repo
 oci-build-params: {}
 src-repo: external-org/external-repo
+src-repo-uri: https://github.com/external-org/external-repo
 src-target-branch: main
 common-pipelines-trigger: false
 dockerfile-path: []

--- a/container/pipeline-base.yml
+++ b/container/pipeline-base.yml
@@ -312,7 +312,7 @@ resources:
   - name: src
     type: git
     source:
-      uri: https://github.com/((src-repo))
+      uri: ((src-repo-uri))
       branch: ((src-branch))
       commit_verification_keys: ((cloud-gov-pgp-keys))
 

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -379,7 +379,7 @@ resources:
   - name: src
     type: git
     source:
-      uri: https://github.com/((src-repo))
+      uri: ((src-repo-uri))
       branch: ((src-branch))
       commit_verification_keys: ((cloud-gov-pgp-keys))
       git_config:

--- a/container/pipeline-pages.yml
+++ b/container/pipeline-pages.yml
@@ -343,7 +343,7 @@ resources:
   - name: src
     type: git
     source:
-      uri: https://github.com/((src-repo))
+      uri: ((src-repo-uri))
       branch: ((src-target-branch))
       commit_verification_keys: ((cloud-gov-pages-gpg-keys))
       paths: ((src-path))


### PR DESCRIPTION
## Changes proposed in this pull request:

- refactor how source repo URIs are defined to allow using SSH URIs for some repos
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

This changes allows us to build images from private repos, which allows us to keep sensitive repos private more easily.
