### PR TITLE
Add tests for builds

### DIFF
--- a/ci/container/external/git-resource/vars.yml
+++ b/ci/container/external/git-resource/vars.yml
@@ -7,3 +7,10 @@ src-source:
   # Since src is a repo outside the cloud-gov org, don't verify commits.
 dockerfile-path: ["container/dockerfiles/git-resource/Dockerfile"]
 dockerfile-trigger: true
+build-test-cmd: build
+build-test-args: []
+build-test-params:
+  DOCKERFILE: common-dockerfiles/container/dockerfiles/git-resource/Dockerfile
+  TARGET: tests
+  IMAGE_ARG_base_image: base-image/image.tar
+  CONTEXT: src

--- a/ci/container/external/pool-resource/vars.yml
+++ b/ci/container/external/pool-resource/vars.yml
@@ -7,3 +7,10 @@ src-source:
   # Since src is a repo outside the cloud-gov org, don't verify commits.
 dockerfile-path: ["container/dockerfiles/pool-resource/Dockerfile"]
 dockerfile-trigger: true
+build-test-cmd: build
+build-test-args: []
+build-test-params:
+  DOCKERFILE: common-dockerfiles/container/dockerfiles/pool-resource/Dockerfile
+  TARGET: tests
+  IMAGE_ARG_base_image: base-image/image.tar
+  CONTEXT: src

--- a/ci/container/external/time-resource/vars.yml
+++ b/ci/container/external/time-resource/vars.yml
@@ -7,3 +7,10 @@ src-source:
   # Since src is a repo outside the cloud-gov org, don't verify commits.
 dockerfile-path: ["container/dockerfiles/time-resource/Dockerfile"]
 dockerfile-trigger: true
+build-test-cmd: build
+build-test-args: []
+build-test-params:
+  DOCKERFILE: common-dockerfiles/container/dockerfiles/time-resource/Dockerfile
+  TARGET: tests
+  IMAGE_ARG_base_image: base-image/image.tar
+  CONTEXT: src

--- a/ci/container/internal/github-release-resource/vars.yml
+++ b/ci/container/internal/github-release-resource/vars.yml
@@ -1,3 +1,9 @@
 image-repository: github-release-resource
 src-repo: cloud-gov/github-release-resource
 src-repo-uri: https://github.com/cloud-gov/github-release-resource
+build-test-cmd: build
+build-test-args: []
+build-test-params:
+  TARGET: tests
+  IMAGE_ARG_base_image: base-image/image.tar
+  CONTEXT: src


### PR DESCRIPTION
## Changes proposed in this pull request:

- sets up test jobs for those container images that already have testing we can use in our own pipelines

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Adding testing to our container images
