### PR TITLE
update when containers build

### DIFF
--- a/container/pipeline-base.yml
+++ b/container/pipeline-base.yml
@@ -112,10 +112,10 @@ jobs:
     plan:
       - in_parallel:
           - get: src
-            trigger: true
+            # trigger: true
 
           - get: base-image
-            trigger: true
+            # trigger: true
             params:
               format: oci
 
@@ -325,7 +325,7 @@ resources:
   - name: weekly
     type: cron-resource
     source:
-      expression: "0 3 * * 2"
+      expression: "0 4 * * 2"
       location: "America/New_York"
 
   - name: monthly

--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -25,7 +25,7 @@ jobs:
     plan:
       - in_parallel:
           - get: src
-            trigger: true
+            #trigger: true
             passed: [code-scan]
 
           - get: base-image
@@ -34,10 +34,10 @@ jobs:
               format: oci
 
           - get: common-pipelines
-            trigger: ((common-pipelines-trigger))
+            #trigger: ((common-pipelines-trigger))
 
           - get: common-dockerfiles
-            trigger: ((dockerfile-trigger))
+            #trigger: ((dockerfile-trigger))
 
       - task: oci-build
         privileged: true

--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -25,7 +25,7 @@ jobs:
     plan:
       - in_parallel:
           - get: src
-            #trigger: true
+            # trigger: true
             passed: [code-scan]
 
           - get: base-image
@@ -34,10 +34,10 @@ jobs:
               format: oci
 
           - get: common-pipelines
-            #trigger: ((common-pipelines-trigger))
+            # trigger: ((common-pipelines-trigger))
 
           - get: common-dockerfiles
-            #trigger: ((dockerfile-trigger))
+            # trigger: ((dockerfile-trigger))
 
       - task: oci-build
         privileged: true

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -136,7 +136,7 @@ jobs:
     plan:
       - in_parallel:
           - get: src
-            trigger: true
+            # trigger: true
 
           - get: base-image
             trigger: true
@@ -144,10 +144,10 @@ jobs:
               format: oci
 
           - get: common-pipelines
-            trigger: ((common-pipelines-trigger))
+            # trigger: ((common-pipelines-trigger))
 
           - get: common-dockerfiles
-            trigger: ((dockerfile-trigger))
+            # trigger: ((dockerfile-trigger))
 
       - task: oci-build
         privileged: true

--- a/container/pipeline-pages.yml
+++ b/container/pipeline-pages.yml
@@ -83,7 +83,7 @@ jobs:
     plan:
       - in_parallel:
           - get: src
-            trigger: true
+            # trigger: true
 
           - get: base-image
             trigger: true
@@ -91,10 +91,10 @@ jobs:
               format: oci
 
           - get: common-pipelines
-            trigger: ((common-pipelines-trigger))
+            # trigger: ((common-pipelines-trigger))
 
           - get: common-dockerfiles
-            trigger: ((dockerfile-trigger))
+            # trigger: ((dockerfile-trigger))
 
       - task: oci-build
         privileged: true


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updates pipelines to only rebuild images weekly when the base image gets updated
- Updates timing of weekly base image rebuild

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Updates the timing of rebuilds so that resource history doesn't get removed as often
