### PR TITLE
use custom dockerfile for simplicity

### DIFF
--- a/ci/container/internal/paketo-jammy-full-hardened-candidate/vars.yml
+++ b/ci/container/internal/paketo-jammy-full-hardened-candidate/vars.yml
@@ -1,6 +1,10 @@
 base-image: paketo-jammy-full
+stig-base-image: paketo-jammy-full
 image-repository: paketo-jammy-full-hardened-candidate
-src-repo: cloud-gov/ubuntu-hardened
-src-repo-uri: https://github.com/cloud-gov/ubuntu-hardened
-src-branch: disa-stig
+src-repo: cloud-gov/paketo-jammy-full-hardened-release
+src-repo-uri: https://github.com/cloud-gov/paketo-jammy-full-hardened-release
+src-branch: initial
 tailoring-file: common-pipelines/container/tailor-stig.xml
+oci-build-params:
+  CONTEXT: src/image
+


### PR DESCRIPTION
## Changes proposed in this pull request:

- Simplifies the building a paketo stack candidate by using a custom dockerfile. The Dockerfile is copied from the ubuntu-hardened disa-stig branch and slightly modified. If this works, the diffs can likely be merged into the ubuntu-harded repository. 

## Security considerations

None. All stig hardening is still performed. 
