### PR TITLE
change channel for slack notifications

### DIFF
--- a/container/pipeline-base.yml
+++ b/container/pipeline-base.yml
@@ -186,7 +186,7 @@ jobs:
         text: |
           :x: Pipeline `$BUILD_PIPELINE_NAME` FAILED to upload image to ECR
           <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-        channel: ((slack-channel-failure))
+        channel: ((slack-channel-notifications))
         username: ((slack-username))
         icon_url: ((slack-icon-url))
 

--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -97,7 +97,7 @@ jobs:
         text: |
           :x: Pipeline `$BUILD_PIPELINE_NAME` FAILED to upload image to ECR
           <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-        channel: ((slack-channel-failure))
+        channel: ((slack-channel-notifications))
         username: ((slack-username))
         icon_url: ((slack-icon-url))
 

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -207,7 +207,7 @@ jobs:
         text: |
           :x: Pipeline `$BUILD_PIPELINE_NAME` FAILED to upload image to ECR
           <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-        channel: ((slack-channel-failure))
+        channel: ((slack-channel-notifications))
         username: ((slack-username))
         icon_url: ((slack-icon-url))
 

--- a/container/pipeline-pages.yml
+++ b/container/pipeline-pages.yml
@@ -70,11 +70,11 @@ jobs:
 
     on_failure:
       put: slack
-      params:
+      params: &slack-failure-params
         text: |
           :x: Pipeline `$BUILD_PIPELINE_NAME` FAILED pull request tasks
           <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-        channel: ((slack-channel-failure))
+        channel: ((slack-channel))
         username: ((slack-username))
         icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 
@@ -151,12 +151,10 @@ jobs:
     on_failure:
       put: slack
       params:
+        <<: *slack-failure-params
         text: |
           :x: Pipeline `$BUILD_PIPELINE_NAME` FAILED to upload image to ECR
           <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-        channel: ((slack-channel))
-        username: ((slack-username))
-        icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 
   - name: continuous-scan
     serial_groups: [container-scans]
@@ -188,12 +186,10 @@ jobs:
     on_failure:
       put: slack
       params:
+        <<: *slack-failure-params
         text: |
           :x: Continuous Scan of `$BUILD_PIPELINE_NAME` FAILED
           <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-        channel: ((slack-channel-failure))
-        username: ((slack-username))
-        icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 
   - name: conmon-scan
     serial_groups: [container-scans]
@@ -224,12 +220,10 @@ jobs:
     on_failure:
       put: slack
       params:
+        <<: *slack-failure-params
         text: |
           :x: ConMon Scan of `$BUILD_PIPELINE_NAME` FAILED
           <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-        channel: ((slack-channel-failure))
-        username: ((slack-username))
-        icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 
   - name: test-stig-build
     plan:


### PR DESCRIPTION
## Changes proposed in this pull request:

- Changes slack channel so failure messages are sent to the notifications channel
- Leaves pages channel the same, except adds yaml anchors

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Moving notifications to a better channel
