### PR TITLE
enables tests for more image builds

### DIFF
--- a/ci/container/external/bosh-io-release-resource/vars.yml
+++ b/ci/container/external/bosh-io-release-resource/vars.yml
@@ -7,3 +7,10 @@ src-source:
   # Since src is a repo outside the cloud-gov org, don't verify commits.
 dockerfile-path: ["container/dockerfiles/bosh-io-release-resource/Dockerfile"]
 dockerfile-trigger: true
+build-test-cmd: build
+build-test-args: []
+build-test-params:
+  DOCKERFILE: common-dockerfiles/container/dockerfiles/bosh-io-release-resource/Dockerfile
+  TARGET: tests
+  IMAGE_ARG_base_image: base-image/image.tar
+  CONTEXT: src

--- a/ci/container/external/bosh-io-stemcell-resource/vars.yml
+++ b/ci/container/external/bosh-io-stemcell-resource/vars.yml
@@ -3,3 +3,9 @@ src-source:
   uri: https://github.com/concourse/bosh-io-stemcell-resource
   branch: master
   # Since src is a repo outside the cloud-gov org, don't verify commits.
+build-test-cmd: build
+build-test-args: []
+build-test-params:
+  TARGET: tests
+  IMAGE_ARG_base_image: base-image/image.tar
+  CONTEXT: src

--- a/ci/container/external/registry-image-resource/vars.yml
+++ b/ci/container/external/registry-image-resource/vars.yml
@@ -7,3 +7,10 @@ src-source:
   # Since src is a repo outside the cloud-gov org, don't verify commits.
 dockerfile-path: ["container/dockerfiles/registry-image-resource/Dockerfile"]
 dockerfile-trigger: true
+build-test-cmd: build
+build-test-args: []
+build-test-params:
+  DOCKERFILE: common-dockerfiles/container/dockerfiles/registry-image-resource/Dockerfile
+  TARGET: tests
+  IMAGE_ARG_base_image: base-image/image.tar
+  CONTEXT: src

--- a/ci/container/external/semver-resource/vars.yml
+++ b/ci/container/external/semver-resource/vars.yml
@@ -7,3 +7,10 @@ src-source:
   # Since src is a repo outside the cloud-gov org, don't verify commits.
 dockerfile-path: ["container/dockerfiles/semver-resource/Dockerfile"]
 dockerfile-trigger: true
+build-test-cmd: build
+build-test-args: []
+build-test-params:
+  DOCKERFILE: common-dockerfiles/container/dockerfiles/semver-resource/Dockerfile
+  TARGET: tests
+  IMAGE_ARG_base_image: base-image/image.tar
+  CONTEXT: src

--- a/ci/container/internal/bosh-deployment-resource/vars.yml
+++ b/ci/container/internal/bosh-deployment-resource/vars.yml
@@ -1,3 +1,9 @@
 image-repository: bosh-deployment-resource
 src-repo: cloud-gov/bosh-deployment-resource
 src-repo-uri: https://github.com/cloud-gov/bosh-deployment-resource
+build-test-cmd: build
+build-test-args: []
+build-test-params:
+  TARGET: tests
+  IMAGE_ARG_base_image: base-image/image.tar
+  CONTEXT: src

--- a/ci/container/internal/s3-resource/vars.yml
+++ b/ci/container/internal/s3-resource/vars.yml
@@ -2,3 +2,10 @@ image-repository: s3-resource
 oci-build-params: { DOCKERFILE: src/Dockerfile }
 src-repo: cloud-gov/s3-resource
 src-repo-uri: https://github.com/cloud-gov/s3-resource
+build-test-cmd: build
+build-test-args: []
+build-test-params:
+  DOCKERFILE: src/Dockerfile
+  TARGET: tests
+  IMAGE_ARG_base_image: base-image/image.tar
+  CONTEXT: src


### PR DESCRIPTION
## Changes proposed in this pull request:

- Enables tests in disa-test and PR pipeline jobs for the following pipelines:
  - bosh-io-release-resource
  - bosh-io-stemcell-resource
  - registry-image-resource
  - semver-resource
  - bosh-deployment-resource
  - s3-resource

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Enabling tests for pipelines
