### PR TITLE
Switch CSB branches back to main

### DIFF
--- a/ci/container/internal/cg-csb/vars.yml
+++ b/ci/container/internal/cg-csb/vars.yml
@@ -6,7 +6,6 @@ oci-build-params:
 slack-channel-failure: "#cg-customer-success"
 src-repo: cloud-gov/csb
 src-repo-uri: https://github.com/cloud-gov/csb
-src-branch: ses-topic
 static-analysis-cmd: sh
 # We skip check updates because trivy tries pulling an image from GHCR but
 # often gets rate limited. Trivy has config databases built into the binary

--- a/ci/container/internal/csb-helper/vars.yml
+++ b/ci/container/internal/csb-helper/vars.yml
@@ -2,6 +2,5 @@ image-repository: csb-helper
 slack-channel-failure: "#cg-customer-success"
 src-repo: cloud-gov/csb
 src-repo-uri: https://github.com/cloud-gov/csb
-src-branch: brokerpak-topic
 oci-build-params:
   CONTEXT: "src/helper"


### PR DESCRIPTION

## Changes proposed in this pull request:

- Since we merged https://github.com/cloud-gov/csb/pull/13, we are ready to build these images off main again.
- By removing `src-branch`, they will default to `main`.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None