### PR TITLE
sets up test for email-resource

### DIFF
--- a/ci/container/external/email-resource/vars.yml
+++ b/ci/container/external/email-resource/vars.yml
@@ -7,3 +7,10 @@ src-source:
   # Since src is a repo outside the cloud-gov org, don't verify commits.
 dockerfile-path: ["container/dockerfiles/email-resource/Dockerfile"]
 dockerfile-trigger: true
+build-test-cmd: build
+build-test-args: []
+build-test-params:
+  DOCKERFILE: common-dockerfiles/container/dockerfiles/email-resource/Dockerfile
+  TARGET: tests
+  IMAGE_ARG_base_image: base-image/image.tar
+  CONTEXT: src

--- a/container/dockerfiles/email-resource/Dockerfile
+++ b/container/dockerfiles/email-resource/Dockerfile
@@ -10,9 +10,15 @@ COPY . .
 RUN export GOPATH=$PWD/go && export PATH=$GOPATH/bin:$PATH
 
 RUN go mod download && \
-go build -o /opt/resource/check check/cmd/*.go && \
-go build -o /opt/resource/in in/cmd/*.go && \
-go build -o /opt/resource/out out/cmd/*.go
+    go build -o /opt/resource/check check/cmd/*.go && \
+    go build -o /opt/resource/in in/cmd/*.go && \
+    go build -o /opt/resource/out out/cmd/*.go
+
+FROM builder as tests
+RUN mkdir ~/.ssh/ && touch ~/.ssh/known_hosts
+RUN ssh-keyscan github.com >>~/.ssh/known_hosts
+RUN go version
+RUN go test ./... -v
 
 FROM ${base_image} AS resource
 COPY --from=builder /opt/resource/ /opt/resource/


### PR DESCRIPTION
## Changes proposed in this pull request:

- adds tests stage to the dockerfile for email-resource
- sets up pipeline to run the tests stage

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Adding and running tests
