### PR TITLE
switch to stig base image for bosh-deployment-resource

### DIFF
--- a/ci/container/internal/bosh-deployment-resource/vars.yml
+++ b/ci/container/internal/bosh-deployment-resource/vars.yml
@@ -8,4 +8,4 @@ build-test-params:
   TARGET: tests
   IMAGE_ARG_base_image: base-image/image.tar
   CONTEXT: src
-tailoring-file: common-pipelines/container/tailor.xml
+tailoring-file: common-pipelines/container/tailor-stig.xml

--- a/ci/container/internal/bosh-deployment-resource/vars.yml
+++ b/ci/container/internal/bosh-deployment-resource/vars.yml
@@ -1,3 +1,4 @@
+base-image: ubuntu-hardened-stig
 image-repository: bosh-deployment-resource
 src-repo: cloud-gov/bosh-deployment-resource
 src-repo-uri: https://github.com/cloud-gov/bosh-deployment-resource
@@ -7,3 +8,4 @@ build-test-params:
   TARGET: tests
   IMAGE_ARG_base_image: base-image/image.tar
   CONTEXT: src
+tailoring-file: common-pipelines/container/tailor.xml


### PR DESCRIPTION
## Changes proposed in this pull request:

- Use the base stig image for the bosh-deployment-resource

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Switching over to base stig image
