### PR TITLE
switch to stig base image for cf-resource

### DIFF
--- a/ci/container/internal/cf-resource/vars.yml
+++ b/ci/container/internal/cf-resource/vars.yml
@@ -1,3 +1,4 @@
+base-image: ubuntu-hardened-stig
 image-repository: cf-resource
 oci-build-params: { DOCKERFILE: src/dockerfiles/ubuntu/Dockerfile }
 src-repo: cloud-gov/cf-resource
@@ -10,3 +11,4 @@ build-test-params:
   TARGET: tests
   IMAGE_ARG_base_image: base-image/image.tar
   CONTEXT: src
+tailoring-file: common-pipelines/container/tailor-stig.xml


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update cf-resource to use the stig base image

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Switching to stig base image
