### PR TITLE
use stig base image for external-domain-broker-testing

### DIFF
--- a/ci/container/internal/external-domain-broker-testing/vars.yml
+++ b/ci/container/internal/external-domain-broker-testing/vars.yml
@@ -1,5 +1,7 @@
+base-image: ubuntu-hardened-stig
 image-repository: external-domain-broker-testing
 oci-build-params: { DOCKERFILE: src/docker/Dockerfile.dev }
 src-repo: cloud-gov/external-domain-broker
 src-repo-uri: https://github.com/cloud-gov/external-domain-broker
 src-target-branch: main
+tailoring-file: common-pipelines/container/tailor-stig.xml


### PR DESCRIPTION
## Changes proposed in this pull request:

- Use stig base image for the external-domain-broker-testing resource

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Updating to use stigs
