### PR TITLE
use stig base image for csb-helper

### DIFF
--- a/ci/container/internal/csb-helper/vars.yml
+++ b/ci/container/internal/csb-helper/vars.yml
@@ -1,6 +1,8 @@
+base-image: ubuntu-hardened-stig
 image-repository: csb-helper
 slack-channel-failure: "#cg-customer-success"
 src-repo: cloud-gov/csb
 src-repo-uri: https://github.com/cloud-gov/csb
 oci-build-params:
   CONTEXT: "src/helper"
+tailoring-file: common-pipelines/container/tailor-stig.xml


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update to use the stig base image for the csb-helper resource

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Update to use stig
