### PR TITLE
use stig base image for github-release-resource

### DIFF
--- a/ci/container/internal/github-release-resource/vars.yml
+++ b/ci/container/internal/github-release-resource/vars.yml
@@ -1,3 +1,4 @@
+base-image: ubuntu-hardened-stig
 image-repository: github-release-resource
 src-repo: cloud-gov/github-release-resource
 src-repo-uri: https://github.com/cloud-gov/github-release-resource
@@ -7,3 +8,4 @@ build-test-params:
   TARGET: tests
   IMAGE_ARG_base_image: base-image/image.tar
   CONTEXT: src
+tailoring-file: common-pipelines/container/tailor-stig.xml


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update to use stig base image for github-release-resource

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Updating to use stig
