### PR TITLE
use stig base image for pulledpork

### DIFF
--- a/ci/container/internal/pulledpork/vars.yml
+++ b/ci/container/internal/pulledpork/vars.yml
@@ -1,4 +1,6 @@
+base-image: ubuntu-hardened-stig
 image-repository: pulledpork
 oci-build-params: { DOCKERFILE: src/ci/docker/pulledpork/Dockerfile }
 src-repo: cloud-gov/cg-snort-boshrelease
 src-repo-uri: https://github.com/cloud-gov/cg-snort-boshrelease
+tailoring-file: common-pipelines/container/tailor-stig.xml


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update to use stig base image for pulledpork

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Update to use stigs
