### PR TITLE
use base stig image for s3-simple-resource

### DIFF
--- a/ci/container/internal/s3-simple-resource/vars.yml
+++ b/ci/container/internal/s3-simple-resource/vars.yml
@@ -1,3 +1,5 @@
+base-image: ubuntu-hardened-stig
 image-repository: s3-simple-resource
 src-repo: cloud-gov/s3-simple-resource
 src-repo-uri: https://github.com/cloud-gov/s3-simple-resource
+tailoring-file: common-pipelines/container/tailor-stig.xml


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update to use stig base image for s3-simple-resource

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Updating to use stigs