### PR TITLE
use stig base image for slack-notification-resource

### DIFF
--- a/ci/container/internal/slack-notification-resource/vars.yml
+++ b/ci/container/internal/slack-notification-resource/vars.yml
@@ -1,4 +1,6 @@
+base-image: ubuntu-hardened-stig
 image-repository: slack-notification-resource
 oci-build-params: { DOCKERFILE: src/dockerfiles/ubuntu/Dockerfile }
 src-repo: cloud-gov/slack-notification-resource
 src-repo-uri: https://github.com/cloud-gov/slack-notification-resource
+tailoring-file: common-pipelines/container/tailor-stig.xml


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update to use stig base image for slack-notification-resource

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Updating to use stigs
