### PR TITLE
Add trigger options

### DIFF
--- a/ci/container/external/base_vars.yml
+++ b/ci/container/external/base_vars.yml
@@ -14,3 +14,4 @@ build-test-args:
   ]
 build-test-params: {}
 daily-scan-time: "0 4 * * *"
+src-trigger: false

--- a/ci/container/external/cloud-service-broker/vars.yml
+++ b/ci/container/external/cloud-service-broker/vars.yml
@@ -7,5 +7,6 @@ src-source:
   # Modified to start with `^v?` instead of `^`.
   tag_regex: ^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
   # Since src is a repo outside the cloud-gov org, don't verify commits.
+src-trigger: true
 dockerfile-path: ["container/dockerfiles/cloud-service-broker/Dockerfile"]
 dockerfile-trigger: true

--- a/ci/container/internal/base_vars.yml
+++ b/ci/container/internal/base_vars.yml
@@ -18,5 +18,6 @@ build-test-args:
   ]
 build-test-params: {}
 src-branch: main
+src-trigger: false
 tailoring-file: common-pipelines/container/tailor.xml
 daily-scan-time: "0 2 * * *"

--- a/ci/container/internal/cg-csb/vars.yml
+++ b/ci/container/internal/cg-csb/vars.yml
@@ -6,6 +6,7 @@ oci-build-params:
 slack-channel-failure: "#cg-customer-success"
 src-repo: cloud-gov/csb
 src-repo-uri: https://github.com/cloud-gov/csb
+src-trigger: true
 static-analysis-cmd: sh
 # We skip check updates because trivy tries pulling an image from GHCR but
 # often gets rate limited. Trivy has config databases built into the binary

--- a/ci/container/internal/csb-helper/vars.yml
+++ b/ci/container/internal/csb-helper/vars.yml
@@ -3,6 +3,7 @@ image-repository: csb-helper
 slack-channel-failure: "#cg-customer-success"
 src-repo: cloud-gov/csb
 src-repo-uri: https://github.com/cloud-gov/csb
+src-trigger: true
 oci-build-params:
   CONTEXT: "src/helper"
 tailoring-file: common-pipelines/container/tailor-stig.xml

--- a/ci/container/internal/external-domain-broker-testing/vars.yml
+++ b/ci/container/internal/external-domain-broker-testing/vars.yml
@@ -4,4 +4,5 @@ oci-build-params: { DOCKERFILE: src/docker/Dockerfile.dev }
 src-repo: cloud-gov/external-domain-broker
 src-repo-uri: https://github.com/cloud-gov/external-domain-broker
 src-target-branch: main
+src-trigger: true
 tailoring-file: common-pipelines/container/tailor-stig.xml

--- a/ci/container/internal/opensearch-dashboards-testing/vars.yml
+++ b/ci/container/internal/opensearch-dashboards-testing/vars.yml
@@ -4,4 +4,5 @@ oci-build-params: { DOCKERFILE: src/docker/opensearch_dashboards/dockerfile }
 src-repo: cloud-gov/opensearch-dashboards-cf-auth-proxy
 src-repo-uri: git@github.com:cloud-gov/opensearch-dashboards-cf-auth-proxy.git
 src-target-branch: main
+src-trigger: true
 tailoring-file: common-pipelines/container/tailor-stig.xml

--- a/ci/container/internal/opensearch-testing/vars.yml
+++ b/ci/container/internal/opensearch-testing/vars.yml
@@ -4,4 +4,5 @@ oci-build-params: { DOCKERFILE: src/docker/opensearch/dockerfile }
 src-repo: cloud-gov/opensearch-dashboards-cf-auth-proxy
 src-repo-uri: git@github.com:cloud-gov/opensearch-dashboards-cf-auth-proxy.git
 src-target-branch: main
+src-trigger: true
 tailoring-file: common-pipelines/container/tailor-stig.xml

--- a/ci/container/pages/base_vars.yml
+++ b/ci/container/pages/base_vars.yml
@@ -4,6 +4,7 @@ stig-base-image: ubuntu-hardened-stig
 stig-base-image-tag: latest
 src-target-branch: main
 src-path: []
+src-trigger: false
 common-pipelines-trigger: false
 dockerfile-path: []
 dockerfile-trigger: false

--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -25,7 +25,7 @@ jobs:
     plan:
       - in_parallel:
           - get: src
-            # trigger: true
+            trigger: ((src-trigger))
             passed: [code-scan]
 
           - get: base-image

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -136,7 +136,7 @@ jobs:
     plan:
       - in_parallel:
           - get: src
-            # trigger: true
+            trigger: ((src-trigger))
 
           - get: base-image
             trigger: true

--- a/container/pipeline-pages.yml
+++ b/container/pipeline-pages.yml
@@ -83,7 +83,7 @@ jobs:
     plan:
       - in_parallel:
           - get: src
-            # trigger: true
+            trigger: ((src-trigger))
 
           - get: base-image
             trigger: true


### PR DESCRIPTION
## Changes proposed in this pull request:

- Sets a variable for the src trigger that defaults to false
- Updates the pipelines that need to trigger on src updates and sets them to true 

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Updating triggers so pipelines run how we expect them to
