### PR TITLE
Fix rwlock not being registered

### DIFF
--- a/ci/container/pipeline.yml
+++ b/ci/container/pipeline.yml
@@ -44,6 +44,7 @@ jobs:
               - concourse-http-jq-resource
               - cron-resource
               - csb-helper
+              - concourse-rwlock-resource
               - external-domain-broker-migrator-testing
               - external-domain-broker-testing
               - general-task


### PR DESCRIPTION
## Changes proposed in this pull request:

- See title and previous PR

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None