### PR TITLE
use stig for cf-cli-resource

### DIFF
--- a/ci/container/external/cf-cli-resource/vars.yml
+++ b/ci/container/external/cf-cli-resource/vars.yml
@@ -1,3 +1,4 @@
+base-image: ubuntu-hardened-stig
 image-repository: cf-cli-resource
 oci-build-params:
   DOCKERFILE: common-dockerfiles/container/dockerfiles/cf-cli-resource/Dockerfile
@@ -7,3 +8,4 @@ src-source:
   # Since src is a repo outside the cloud-gov org, don't verify commits.
 dockerfile-path: ["container/dockerfiles/cf-cli-resource/Dockerfile"]
 dockerfile-trigger: true
+tailoring-file: common-pipelines/container/tailor-stig.xml


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update to use stig base image for cf-cli-resource

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Using stig base image
