### PR TITLE
use stig tailoring file

### DIFF
--- a/ci/container/internal/cg-csb/vars.yml
+++ b/ci/container/internal/cg-csb/vars.yml
@@ -16,3 +16,4 @@ static-analysis-cmd: sh
 static-analysis-args:
   - "-c"
   - "set -e; trivy config --skip-check-update --exit-code 1 src/brokerpaks/*"
+tailoring-file: common-pipelines/container/tailor-stig.xml


### PR DESCRIPTION
## Changes proposed in this pull request:

- Now that the cloud-service-broker uses stigs this image now needs to use the stig tailoring file

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Using stig tailoring file
