### PR TITLE
use stig base image for pool-resource

### DIFF
--- a/ci/container/external/pool-resource/vars.yml
+++ b/ci/container/external/pool-resource/vars.yml
@@ -1,3 +1,4 @@
+base-image: ubuntu-hardened-stig
 image-repository: pool-resource
 oci-build-params:
   DOCKERFILE: common-dockerfiles/container/dockerfiles/pool-resource/Dockerfile
@@ -14,3 +15,4 @@ build-test-params:
   TARGET: tests
   IMAGE_ARG_base_image: base-image/image.tar
   CONTEXT: src
+tailoring-file: common-pipelines/container/tailor-stig.xml


### PR DESCRIPTION
## Changes proposed in this pull request:

- Use stig base image for pool-resource

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Using stig base image
