### PR TITLE
use stig base image for pages nginx-v1

### DIFF
--- a/ci/container/pages/nginx-v1/vars.yml
+++ b/ci/container/pages/nginx-v1/vars.yml
@@ -1,5 +1,7 @@
+base-image: ubuntu-hardened-stig
 image-repository: pages-nginx-v1
 oci-build-params: { CONTEXT: src/nginx/v1 }
 src-repo: cloud-gov/pages-images
 src-repo-uri: https://github.com/cloud-gov/pages-images
 src-path: [nginx/v1/*]
+tailoring-file: common-pipelines/container/tailor-stig.xml


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updates to use stig base image for pages nginx-v1 image

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Using stig base image
