### PR TITLE
use stig base image for pages postgres-v15

### DIFF
--- a/ci/container/pages/postgres-v15/vars.yml
+++ b/ci/container/pages/postgres-v15/vars.yml
@@ -1,5 +1,7 @@
+base-image: ubuntu-hardened-stig
 image-repository: pages-postgres-v15
 oci-build-params: { CONTEXT: src/postgres/v15 }
 src-repo: cloud-gov/pages-images
 src-repo-uri: https://github.com/cloud-gov/pages-images
 src-path: [postgres/v15/*]
+tailoring-file: common-pipelines/container/tailor-stig.xml


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updates to use stig base image for pages postgres-v15 image

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Using stig base image
