### PR TITLE
remove git tests

### DIFF
--- a/ci/container/external/git-resource/vars.yml
+++ b/ci/container/external/git-resource/vars.yml
@@ -8,11 +8,4 @@ src-source:
   # Since src is a repo outside the cloud-gov org, don't verify commits.
 dockerfile-path: ["container/dockerfiles/git-resource/Dockerfile"]
 dockerfile-trigger: true
-build-test-cmd: build
-build-test-args: []
-build-test-params:
-  DOCKERFILE: common-dockerfiles/container/dockerfiles/git-resource/Dockerfile
-  TARGET: tests
-  IMAGE_ARG_base_image: base-image/image.tar
-  CONTEXT: src
 tailoring-file: common-pipelines/container/tailor-stig.xml


### PR DESCRIPTION
## Changes proposed in this pull request:

- Removes running the build test for the git-resource as the upstream where we pull these tests from also fails

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Removing build tests that appear to have never worked even in upstream
