### PR TITLE
implement the build-test task in the main job for each pipeline

### DIFF
--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -44,6 +44,30 @@ jobs:
         file: common-pipelines/container/oci-build.yml
         params: ((oci-build-params)) # for available params, see https://github.com/concourse/oci-build-task#params
 
+      - task: build-test
+        input_mapping:
+          base-image: stig-base-image
+        privileged: true
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              aws_access_key_id: ((ecr_aws_key))
+              aws_secret_access_key: ((ecr_aws_secret))
+              repository: oci-build-task
+              aws_region: us-gov-west-1
+              tag: latest
+          inputs:
+            - name: src
+            - name: base-image
+            - name: common-pipelines
+            - name: common-dockerfiles
+          params: ((build-test-params))
+          run:
+            path: ((build-test-cmd))
+            args: ((build-test-args))
+
       - in_parallel:
           - task: clamav-scan
             file: common-pipelines/container/clamav-scan.yml

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -154,6 +154,30 @@ jobs:
         file: common-pipelines/container/oci-build.yml
         params: ((oci-build-params)) # for available params, see https://github.com/concourse/oci-build-task#params
 
+      - task: build-test
+        input_mapping:
+          base-image: stig-base-image
+        privileged: true
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              aws_access_key_id: ((ecr_aws_key))
+              aws_secret_access_key: ((ecr_aws_secret))
+              repository: oci-build-task
+              aws_region: us-gov-west-1
+              tag: latest
+          inputs:
+            - name: src
+            - name: base-image
+            - name: common-pipelines
+            - name: common-dockerfiles
+          params: ((build-test-params))
+          run:
+            path: ((build-test-cmd))
+            args: ((build-test-args))
+
       - in_parallel:
           - task: clamav-scan
             file: common-pipelines/container/clamav-scan.yml

--- a/container/pipeline-pages.yml
+++ b/container/pipeline-pages.yml
@@ -101,6 +101,30 @@ jobs:
         file: common-pipelines/container/oci-build.yml
         params: ((oci-build-params)) # for available params, see https://github.com/concourse/oci-build-task#params
 
+      - task: build-test
+        input_mapping:
+          base-image: stig-base-image
+        privileged: true
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              aws_access_key_id: ((ecr_aws_key))
+              aws_secret_access_key: ((ecr_aws_secret))
+              repository: oci-build-task
+              aws_region: us-gov-west-1
+              tag: latest
+          inputs:
+            - name: src
+            - name: base-image
+            - name: common-pipelines
+            - name: common-dockerfiles
+          params: ((build-test-params))
+          run:
+            path: ((build-test-cmd))
+            args: ((build-test-args))
+
       - in_parallel:
           - task: clamav-scan
             file: common-pipelines/container/clamav-scan.yml


### PR DESCRIPTION
## Changes proposed in this pull request:

- This adds the build-test task to the main job for each of our pipelines. This will allow us to implement currently existing tests for images, as well as allow for more tests to be added in the future

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Implementing testing on container images
