### PR TITLE
input mapping not needed

### DIFF
--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -45,8 +45,6 @@ jobs:
         params: ((oci-build-params)) # for available params, see https://github.com/concourse/oci-build-task#params
 
       - task: build-test
-        input_mapping:
-          base-image: stig-base-image
         privileged: true
         config:
           platform: linux

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -155,8 +155,6 @@ jobs:
         params: ((oci-build-params)) # for available params, see https://github.com/concourse/oci-build-task#params
 
       - task: build-test
-        input_mapping:
-          base-image: stig-base-image
         privileged: true
         config:
           platform: linux

--- a/container/pipeline-pages.yml
+++ b/container/pipeline-pages.yml
@@ -102,8 +102,6 @@ jobs:
         params: ((oci-build-params)) # for available params, see https://github.com/concourse/oci-build-task#params
 
       - task: build-test
-        input_mapping:
-          base-image: stig-base-image
         privileged: true
         config:
           platform: linux


### PR DESCRIPTION
## Changes proposed in this pull request:

- input_mapping isn't needed for the main job

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just removing unneeded input mapping
