### PR TITLE
Remove concourse-http-jq-resource

### DIFF
--- a/ci/container/internal/concourse-http-jq-resource/vars.yml
+++ b/ci/container/internal/concourse-http-jq-resource/vars.yml
@@ -1,5 +1,0 @@
-base-image: ubuntu-hardened-stig
-image-repository: concourse-http-jq-resource
-src-repo: cloud-gov/concourse-http-jq-resource
-src-repo-uri: https://github.com/cloud-gov/concourse-http-jq-resource
-tailoring-file: common-pipelines/container/tailor-stig.xml

--- a/ci/container/pipeline.yml
+++ b/ci/container/pipeline.yml
@@ -41,7 +41,6 @@ jobs:
               - cflinuxfs4-hardened-candidate
               - cg-csb
               - clamav-rest-candidate
-              - concourse-http-jq-resource
               - concourse-rwlock-resource
               - cron-resource
               - csb-helper


### PR DESCRIPTION
## Changes proposed in this pull request:

- Removes `concourse-http-jq-resource` from common-pipelines repo, this resource is no longer needed.
- Part of https://github.com/cloud-gov/private/issues/2688
-

## Security considerations

This reduces the amount of code and images which need to be maintained
