### PR TITLE
remove v6 and v7 of cf cli

### DIFF
--- a/container/dockerfiles/cf-cli-resource/Dockerfile
+++ b/container/dockerfiles/cf-cli-resource/Dockerfile
@@ -16,23 +16,12 @@ RUN curl -SL "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_
   && chmod +x /usr/local/bin/yq \
   && yq --version
 
-ARG CF_CLI_6_VERSION=6.53.0
-RUN mkdir -p /opt/cf-cli-${CF_CLI_6_VERSION} \
-  && curl -SL "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_6_VERSION}" \
-  | tar -zxC /opt/cf-cli-${CF_CLI_6_VERSION} \
-  && ln -s /opt/cf-cli-${CF_CLI_6_VERSION}/cf /usr/local/bin
-
-ARG CF_CLI_7_VERSION=7.8.0
-RUN mkdir -p /opt/cf-cli-${CF_CLI_7_VERSION} \
-  && curl -SL "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_7_VERSION}" \
-  | tar -zxC /opt/cf-cli-${CF_CLI_7_VERSION} \
-  && ln -s /opt/cf-cli-${CF_CLI_7_VERSION}/cf7 /usr/local/bin
-
 ARG CF_CLI_8_VERSION=8.17.0
 RUN mkdir -p /opt/cf-cli-${CF_CLI_8_VERSION} \
   && curl -SL "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_8_VERSION}" \
   | tar -zxC /opt/cf-cli-${CF_CLI_8_VERSION} \
-  && ln -s /opt/cf-cli-${CF_CLI_8_VERSION}/cf8 /usr/local/bin
+  && ln -s /opt/cf-cli-${CF_CLI_8_VERSION}/cf8 /usr/local/bin \
+  && ln -s /opt/cf-cli-${CF_CLI_8_VERSION}/cf /usr/local/bin
 
 ARG SHELLSPEC_VERSION=0.28.1
 RUN mkdir -p /opt \


### PR DESCRIPTION
## Changes proposed in this pull request:

- Remove v6 and v7 of the cf cli from the cf-cli-resource docker image
- Set up cf and cf8 command to be the same

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Removing deprecated versions of cf cli
