### PR TITLE
remove testing images that are no longer needed

### DIFF
--- a/ci/container/internal/external-domain-broker-migrator-testing/vars.yml
+++ b/ci/container/internal/external-domain-broker-migrator-testing/vars.yml
@@ -1,7 +1,0 @@
-base-image: ubuntu-hardened-stig
-image-repository: external-domain-broker-migrator-testing
-oci-build-params: { DOCKERFILE: src/docker/Dockerfile.dev }
-src-repo: cloud-gov/external-domain-broker-migrator
-src-repo-uri: https://github.com/cloud-gov/external-domain-broker-migrator
-src-target-branch: main
-tailoring-file: common-pipelines/container/tailor-stig.xml

--- a/ci/container/internal/legacy-domain-certificate-renewer-testing/vars.yml
+++ b/ci/container/internal/legacy-domain-certificate-renewer-testing/vars.yml
@@ -1,7 +1,0 @@
-base-image: ubuntu-hardened-stig
-image-repository: legacy-domain-certificate-renewer-testing
-oci-build-params: { DOCKERFILE: src/docker/Dockerfile.dev }
-src-repo: cloud-gov/legacy-domain-certificate-renewer
-src-repo-uri: https://github.com/cloud-gov/legacy-domain-certificate-renewer
-src-target-branch: main
-tailoring-file: common-pipelines/container/tailor-stig.xml


### PR DESCRIPTION
## Changes proposed in this pull request:

- remove testing images that are no longer needed
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Deleting unused software is good for maintenance and reduces attack surface
