### PR TITLE
remove use of trivy in all pipelines

### DIFF
--- a/ci/container/internal/cg-csb/vars.yml
+++ b/ci/container/internal/cg-csb/vars.yml
@@ -7,13 +7,4 @@ slack-channel-failure: "#cg-customer-success"
 src-repo: cloud-gov/csb
 src-repo-uri: https://github.com/cloud-gov/csb
 src-trigger: true
-static-analysis-cmd: sh
-# We skip check updates because trivy tries pulling an image from GHCR but
-# often gets rate limited. Trivy has config databases built into the binary
-# and we update it fairly often, whenever we rebuild general-task. Especially
-# since we do not depend on the vulnerability scanning, only the misconfig
-# checks, that is often enough.
-static-analysis-args:
-  - "-c"
-  - "set -e; trivy config --skip-check-update --exit-code 1 src/brokerpaks/*"
 tailoring-file: common-pipelines/container/tailor-stig.xml

--- a/container/pipeline-base.yml
+++ b/container/pipeline-base.yml
@@ -1,26 +1,4 @@
 jobs:
-  - name: code-scan
-    plan:
-      - get: pull-request
-        version: every
-        trigger: true
-      - task: scan
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              aws_access_key_id: ((ecr_aws_key))
-              aws_secret_access_key: ((ecr_aws_secret))
-              repository: general-task
-              aws_region: us-gov-west-1
-              tag: latest
-          run:
-            path: sh
-            args:
-              - "-c"
-              - "set -e; trivy repo --scanners vuln,misconfig,secret https://github.com/((src-repo))"
-
   - name: pull-request
     plan:
       - in_parallel:

--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -1,25 +1,4 @@
 jobs:
-  - name: code-scan
-    plan:
-      - get: src
-        trigger: true
-      - task: scan
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              aws_access_key_id: ((ecr_aws_key))
-              aws_secret_access_key: ((ecr_aws_secret))
-              repository: general-task
-              aws_region: us-gov-west-1
-              tag: latest
-          run:
-            path: sh
-            args:
-              - "-c"
-              - "set -e; trivy repo --scanners vuln,misconfig,secret ((src-source.uri))"
-
   - name: main
     serial_groups: [container-scans]
     plan:

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -1,28 +1,4 @@
 jobs:
-  - name: code-scan
-    plan:
-      - get: pull-request
-        version: every
-        trigger: true
-      - task: scan
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              aws_access_key_id: ((ecr_aws_key))
-              aws_secret_access_key: ((ecr_aws_secret))
-              repository: general-task
-              aws_region: us-gov-west-1
-              tag: latest
-          params:
-            GITHUB_TOKEN: ((cg-ci-bot-ghtoken))
-          run:
-            path: sh
-            args:
-              - "-c"
-              - "set -e; trivy repo --scanners vuln,misconfig,secret https://github.com/((src-repo))"
-
   - name: pull-request
     plan:
       - in_parallel:

--- a/container/pipeline-pages.yml
+++ b/container/pipeline-pages.yml
@@ -1,26 +1,4 @@
 jobs:
-  - name: code-scan
-    plan:
-      - get: pull-request
-        version: every
-        trigger: true
-      - task: scan
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              aws_access_key_id: ((ecr_aws_key))
-              aws_secret_access_key: ((ecr_aws_secret))
-              repository: general-task
-              aws_region: us-gov-west-1
-              tag: latest
-          run:
-            path: sh
-            args:
-              - "-c"
-              - "set -e; trivy repo --scanners vuln,misconfig,secret https://github.com/((src-repo))"
-
   - name: pull-request
     plan:
       - in_parallel:


### PR DESCRIPTION
## Changes proposed in this pull request:

- remove use of trivy in all pipelines

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

There have been multiple supply chain attacks against Trivy, so we are removing all use of it
