### PR TITLE
remove references to code-scan job

### DIFF
--- a/container/pipeline-base.yml
+++ b/container/pipeline-base.yml
@@ -5,7 +5,6 @@ jobs:
           - get: pull-request
             version: every
             trigger: true
-            passed: [code-scan]
 
           - get: base-image
             trigger: true

--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -5,7 +5,6 @@ jobs:
       - in_parallel:
           - get: src
             trigger: ((src-trigger))
-            passed: [code-scan]
 
           - get: base-image
             trigger: true
@@ -181,7 +180,6 @@ jobs:
     plan:
       - in_parallel:
           - get: src
-            passed: [code-scan]
 
           - get: stig-base-image
             params:

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -5,7 +5,6 @@ jobs:
           - get: pull-request
             version: every
             trigger: true
-            passed: [code-scan]
 
           - get: base-image
             trigger: true

--- a/container/pipeline-pages.yml
+++ b/container/pipeline-pages.yml
@@ -5,7 +5,6 @@ jobs:
           - get: src
             resource: pull-request
             trigger: true
-            passed: [code-scan]
 
           - get: base-image
             trigger: true


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fix for #293

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Follow up to #293
