### PR TITLE
update to the latest cf cli version

### DIFF
--- a/container/dockerfiles/cf-cli-resource/Dockerfile
+++ b/container/dockerfiles/cf-cli-resource/Dockerfile
@@ -16,7 +16,7 @@ RUN curl -SL "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_
   && chmod +x /usr/local/bin/yq \
   && yq --version
 
-ARG CF_CLI_8_VERSION=8.17.0
+ARG CF_CLI_8_VERSION=8.18.0
 RUN mkdir -p /opt/cf-cli-${CF_CLI_8_VERSION} \
   && curl -SL "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_8_VERSION}" \
   | tar -zxC /opt/cf-cli-${CF_CLI_8_VERSION} \


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updates to the latest version of the cf cli (v8.18.0)

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Keeping the cf cli updated to resolve CVEs
