### PR TITLE
configure grype scans for stdlib issues

### DIFF
--- a/container/grype.yaml
+++ b/container/grype.yaml
@@ -1,9 +1,26 @@
 #Grype ignore configurations.
 
 ignore:
-  - vulnerability: CVE-2007-4642        #false positive, alerting on package of same name
-  - vulnerability: CVE-2007-4644        #false positive, alerting on package of same name
-  - vulnerability: CVE-2018-20225       #disputed as intended functionality
-  - vulnerability: CVE-2018-9057        #false positive as outlined here: https://github.com/anchore/grype/issues/1377
-  - vulnerability: CVE-2022-29217       #current jwt package contains the patch that fixes this: https://ubuntu.com/security/CVE-2022-29217
-  - vulnerability: GHSA-ffqj-6fqr-9h24  #current jwt package contains the patch that fixes this: https://ubuntu.com/security/CVE-2022-29217
+  #go stdlib packages are often false positives. Tools like govulncheck should be used instead
+  - package:
+      name: stdlib
+      language: go
+      type: go-module
+
+  #false positive, alerting on package of same name
+  - vulnerability: CVE-2007-4642
+
+  #false positive, alerting on package of same name
+  - vulnerability: CVE-2007-4644
+
+  #disputed as intended functionality
+  - vulnerability: CVE-2018-20225
+
+  #false positive as outlined here: https://github.com/anchore/grype/issues/1377
+  - vulnerability: CVE-2018-9057
+
+  #current jwt package contains the patch that fixes this: https://ubuntu.com/security/CVE-2022-29217
+  - vulnerability: CVE-2022-29217
+
+  #current jwt package contains the patch that fixes this: https://ubuntu.com/security/CVE-2022-29217
+  - vulnerability: GHSA-ffqj-6fqr-9h24

--- a/container/scan-image.sh
+++ b/container/scan-image.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-grype image/image.tar -c ${GRYPEPATH} --only-fixed -q -o json --file cves/output.json
-grype image/image.tar -c ${GRYPEPATH} --only-fixed -q -o table --file table.txt
+grype image/image.tar -c ${GRYPEPATH} --only-fixed --by-cve -q -o json --file cves/output.json
+grype image/image.tar -c ${GRYPEPATH} --only-fixed --by-cve -q -o table --file table.txt
 
 cat cves/output.json | jq '.matches | .[]? |  .vulnerability.severity' >> severity.txt
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updates grype config to ignore go stdlib packages as they are often false positives
- Updates formatting of grype config file to be more readable
- Use the --by-cve flag to display results by their CVE number. This saves us processing time later.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Reducing the number of false positives to have a better maintenance experience and increase ability to resolve legitimate CVEs.
