### PR TITLE
use the time resource instead of cron for weekly rebuild

### DIFF
--- a/container/pipeline-base.yml
+++ b/container/pipeline-base.yml
@@ -105,7 +105,7 @@ jobs:
             params:
               format: oci
 
-          - get: weekly
+          - get: weekly-rebuild
             trigger: true
 
           - get: common-pipelines
@@ -314,10 +314,12 @@ resources:
       expression: ((daily-scan-time))
       location: "America/New_York"
 
-  - name: weekly
-    type: cron-resource
+  - name: weekly-rebuild
+    type: time
     source:
-      expression: "0 4 * * 2"
+      start: 3:00 AM
+      stop: 3:05 AM
+      days: [Tuesday]
       location: "America/New_York"
 
   - name: monthly


### PR DESCRIPTION
## Changes proposed in this pull request:

- This updates the pipelines to use the time resource instead of the cron resource for our weekly updates.
- This is necessary because using the cron resource for the weekly trigger causes the base image to be rebuilt twice, and by extension the rest of our images too. When the cron resource rebuilds it re-triggers jobs if the trigger is set to happen within the last hour of the rebuild.
- The time resource doesn't suffer from this same issue, and limiting the time that this can trigger to 5 minutes means that it triggering twice should not happen.
- This also adjusts the trigger to occur an hour earlier, just to allow the images more time to build before the business day starts.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

This keeps our weekly rebuilds, but should improve the functionality.
