### PR TITLE
Add staging jobs

### DIFF
--- a/container/pipeline-base.yml
+++ b/container/pipeline-base.yml
@@ -163,14 +163,13 @@ jobs:
             file: common-pipelines/container/software-inventory.yml
             image: image
 
-          - put: image
+          - put: staging-image
             inputs:
               - image
               - src
             no_get: true
             params:
               image: image/image.tar
-              tag: staging
 
     on_failure:
       put: slack
@@ -376,6 +375,15 @@ resources:
       aws_secret_access_key: ((ecr_aws_secret))
       repository: ((image-repository))
       tag: latest
+      aws_region: us-gov-west-1
+
+  - name: staging-image
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: ((image-repository))
+      tag: staging
       aws_region: us-gov-west-1
 
   - name: pull-request

--- a/container/pipeline-base.yml
+++ b/container/pipeline-base.yml
@@ -93,15 +93,106 @@ jobs:
         status: success
       get_params: { skip_download: true }
 
+  - name: staging
+    serial_groups: [container-scans]
+    plan:
+      - in_parallel:
+          - get: src
+            trigger: true
+
+          - get: base-image
+            trigger: true
+            params:
+              format: oci
+
+          - get: common-pipelines
+
+          - get: common-dockerfiles
+
+      - task: oci-build
+        privileged: true
+        file: common-pipelines/container/oci-build.yml
+        params: ((oci-build-params))
+
+      - task: build-test
+        privileged: true
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              aws_access_key_id: ((ecr_aws_key))
+              aws_secret_access_key: ((ecr_aws_secret))
+              repository: oci-build-task
+              aws_region: us-gov-west-1
+              tag: latest
+          inputs:
+            - name: src
+            - name: base-image
+            - name: common-pipelines
+            - name: common-dockerfiles
+          params: ((build-test-params))
+          run:
+            path: ((build-test-cmd))
+            args: ((build-test-args))
+
+      - in_parallel:
+          - task: clamav-scan
+            file: common-pipelines/container/clamav-scan.yml
+            image: image
+
+          - task: usg-audit
+            privileged: true
+            file: common-pipelines/container/usg-audit.yml
+            image: image
+            params:
+              IMAGENAME: ((image-repository))
+              TAILORINGFILE: ((tailoring-file))
+
+          - task: scan-image
+            file: common-pipelines/container/scan-image.yml
+            params:
+              IMAGENAME: ((image-repository))
+              GRYPEPATH: ((grype-path))
+
+      - task: cve-check
+        file: common-pipelines/container/cve-check.yml
+
+      - in_parallel:
+          - task: software-inventory
+            file: common-pipelines/container/software-inventory.yml
+            image: image
+
+          - put: image
+            inputs:
+              - image
+              - src
+            no_get: true
+            params:
+              image: image/image.tar
+              tag: staging
+
+    on_failure:
+      put: slack
+      params:
+        text: |
+          :warning: Pipeline `$BUILD_PIPELINE_NAME` STAGING build FAILED
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: ((slack-channel-notifications))
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+
   - name: main
     serial_groups: [container-scans]
     plan:
       - in_parallel:
           - get: src
-            # trigger: true
+            trigger: ((src-trigger))
+            passed: [staging]
 
           - get: base-image
-            # trigger: true
+            trigger: true
+            passed: [staging]
             params:
               format: oci
 

--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -173,14 +173,13 @@ jobs:
             file: common-pipelines/container/software-inventory.yml
             image: image
 
-          - put: image
+          - put: staging-image
             inputs:
               - image
               - src
             no_get: true
             params:
               image: image/image.tar
-              tag: staging
 
     on_failure:
       put: slack
@@ -403,6 +402,15 @@ resources:
       aws_secret_access_key: ((ecr_aws_secret))
       repository: ((image-repository))
       tag: latest
+      aws_region: us-gov-west-1
+
+  - name: staging-image
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: ((image-repository))
+      tag: staging
       aws_region: us-gov-west-1
 
   - name: slack

--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -104,6 +104,199 @@ jobs:
         username: ((slack-username))
         icon_url: ((slack-icon-url))
 
+  - name: staging
+    serial_groups: [container-scans]
+    plan:
+      - in_parallel:
+          - get: src
+            trigger: true
+
+          - get: base-image
+            trigger: true
+            params:
+              format: oci
+
+          - get: common-pipelines
+
+          - get: common-dockerfiles
+
+      - task: oci-build
+        privileged: true
+        file: common-pipelines/container/oci-build.yml
+        params: ((oci-build-params))
+
+      - task: build-test
+        privileged: true
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              aws_access_key_id: ((ecr_aws_key))
+              aws_secret_access_key: ((ecr_aws_secret))
+              repository: oci-build-task
+              aws_region: us-gov-west-1
+              tag: latest
+          inputs:
+            - name: src
+            - name: base-image
+            - name: common-pipelines
+            - name: common-dockerfiles
+          params: ((build-test-params))
+          run:
+            path: ((build-test-cmd))
+            args: ((build-test-args))
+
+      - in_parallel:
+          - task: clamav-scan
+            file: common-pipelines/container/clamav-scan.yml
+            image: image
+
+          - task: usg-audit
+            file: common-pipelines/container/usg-audit.yml
+            image: image
+            params:
+              IMAGENAME: ((image-repository))
+              TAILORINGFILE: ((tailoring-file))
+
+          - task: scan-image
+            file: common-pipelines/container/scan-image.yml
+            params:
+              IMAGENAME: ((image-repository))
+              GRYPEPATH: ((grype-path))
+
+      - task: cve-check
+        file: common-pipelines/container/cve-check.yml
+
+      - in_parallel:
+          - task: software-inventory
+            file: common-pipelines/container/software-inventory.yml
+            image: image
+
+          - put: image
+            inputs:
+              - image
+              - src
+            no_get: true
+            params:
+              image: image/image.tar
+              tag: staging
+
+    on_failure:
+      put: slack
+      params:
+        text: |
+          :warning: Pipeline `$BUILD_PIPELINE_NAME` STAGING build FAILED
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: ((slack-channel-notifications))
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+
+  - name: main
+    serial_groups: [container-scans]
+    plan:
+      - in_parallel:
+          - get: src
+            trigger: ((src-trigger))
+            passed: [staging]
+
+          - get: base-image
+            trigger: true
+            passed: [staging]
+            params:
+              format: oci
+
+          - get: common-pipelines
+            # trigger: ((common-pipelines-trigger))
+
+          - get: common-dockerfiles
+            # trigger: ((dockerfile-trigger))
+
+      - task: oci-build
+        privileged: true
+        file: common-pipelines/container/oci-build.yml
+        params: ((oci-build-params)) # for available params, see https://github.com/concourse/oci-build-task#params
+
+      - task: build-test
+        privileged: true
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              aws_access_key_id: ((ecr_aws_key))
+              aws_secret_access_key: ((ecr_aws_secret))
+              repository: oci-build-task
+              aws_region: us-gov-west-1
+              tag: latest
+          inputs:
+            - name: src
+            - name: base-image
+            - name: common-pipelines
+            - name: common-dockerfiles
+          params: ((build-test-params))
+          run:
+            path: ((build-test-cmd))
+            args: ((build-test-args))
+
+      - in_parallel:
+          - task: clamav-scan
+            file: common-pipelines/container/clamav-scan.yml
+            image: image
+
+          - task: usg-audit
+            file: common-pipelines/container/usg-audit.yml
+            image: image
+            params:
+              IMAGENAME: ((image-repository))
+              TAILORINGFILE: ((tailoring-file))
+
+          - task: scan-image
+            file: common-pipelines/container/scan-image.yml
+            params:
+              IMAGENAME: ((image-repository))
+              GRYPEPATH: ((grype-path))
+
+      - task: cve-check
+        file: common-pipelines/container/cve-check.yml
+
+      - in_parallel:
+          - task: import-scan
+            file: common-pipelines/container/import-scan.yml
+            params:
+              IMAGENAME: ((image-repository))
+
+          - task: software-inventory
+            file: common-pipelines/container/software-inventory.yml
+            image: image
+
+          - put: audit-xml-file
+            no_get: true
+            params:
+              file: audit/((image-repository))-audit.xml
+
+          - put: audit-html-file
+            no_get: true
+            params:
+              file: audit/((image-repository))-audit.html
+
+          - put: image
+            inputs:
+              - image
+              - src
+            no_get: true
+            params:
+              image: image/image.tar
+              additional_tags: src/.git/short_ref
+
+    on_failure:
+      put: slack
+      params:
+        <<: *slack-failure-params
+        text: |
+          :x: Pipeline `$BUILD_PIPELINE_NAME` FAILED to upload image to ECR
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+
   - name: continuous-scan
     serial_groups: [container-scans]
     plan:

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -117,15 +117,105 @@ jobs:
         status: success
       get_params: { skip_download: true }
 
+  - name: staging
+    serial_groups: [container-scans]
+    plan:
+      - in_parallel:
+          - get: src
+            trigger: true
+
+          - get: base-image
+            trigger: true
+            params:
+              format: oci
+
+          - get: common-pipelines
+
+          - get: common-dockerfiles
+
+      - task: oci-build
+        privileged: true
+        file: common-pipelines/container/oci-build.yml
+        params: ((oci-build-params))
+
+      - task: build-test
+        privileged: true
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              aws_access_key_id: ((ecr_aws_key))
+              aws_secret_access_key: ((ecr_aws_secret))
+              repository: oci-build-task
+              aws_region: us-gov-west-1
+              tag: latest
+          inputs:
+            - name: src
+            - name: base-image
+            - name: common-pipelines
+            - name: common-dockerfiles
+          params: ((build-test-params))
+          run:
+            path: ((build-test-cmd))
+            args: ((build-test-args))
+
+      - in_parallel:
+          - task: clamav-scan
+            file: common-pipelines/container/clamav-scan.yml
+            image: image
+
+          - task: usg-audit
+            file: common-pipelines/container/usg-audit.yml
+            image: image
+            params:
+              IMAGENAME: ((image-repository))
+              TAILORINGFILE: ((tailoring-file))
+
+          - task: scan-image
+            file: common-pipelines/container/scan-image.yml
+            params:
+              IMAGENAME: ((image-repository))
+              GRYPEPATH: ((grype-path))
+
+      - task: cve-check
+        file: common-pipelines/container/cve-check.yml
+
+      - in_parallel:
+          - task: software-inventory
+            file: common-pipelines/container/software-inventory.yml
+            image: image
+
+          - put: image
+            inputs:
+              - image
+              - src
+            no_get: true
+            params:
+              image: image/image.tar
+              tag: staging
+
+    on_failure:
+      put: slack
+      params:
+        text: |
+          :warning: Pipeline `$BUILD_PIPELINE_NAME` STAGING build FAILED
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: ((slack-channel-notifications))
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+
   - name: main
     serial_groups: [container-scans]
     plan:
       - in_parallel:
           - get: src
             trigger: ((src-trigger))
+            passed: [staging]
 
           - get: base-image
             trigger: true
+            passed: [staging]
             params:
               format: oci
 

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -186,14 +186,13 @@ jobs:
             file: common-pipelines/container/software-inventory.yml
             image: image
 
-          - put: image
+          - put: staging-image
             inputs:
               - image
               - src
             no_get: true
             params:
               image: image/image.tar
-              tag: staging
 
     on_failure:
       put: slack
@@ -418,6 +417,15 @@ resources:
       aws_secret_access_key: ((ecr_aws_secret))
       repository: ((image-repository))
       tag: latest
+      aws_region: us-gov-west-1
+
+  - name: staging-image
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: ((image-repository))
+      tag: staging
       aws_region: us-gov-west-1
 
   - name: pull-request

--- a/container/pipeline-pages.yml
+++ b/container/pipeline-pages.yml
@@ -58,15 +58,105 @@ jobs:
         username: ((slack-username))
         icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 
+  - name: staging
+    serial_groups: [container-scans]
+    plan:
+      - in_parallel:
+          - get: src
+            trigger: true
+
+          - get: base-image
+            trigger: true
+            params:
+              format: oci
+
+          - get: common-pipelines
+
+          - get: common-dockerfiles
+
+      - task: oci-build
+        privileged: true
+        file: common-pipelines/container/oci-build.yml
+        params: ((oci-build-params))
+
+      - task: build-test
+        privileged: true
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              aws_access_key_id: ((ecr_aws_key))
+              aws_secret_access_key: ((ecr_aws_secret))
+              repository: oci-build-task
+              aws_region: us-gov-west-1
+              tag: latest
+          inputs:
+            - name: src
+            - name: base-image
+            - name: common-pipelines
+            - name: common-dockerfiles
+          params: ((build-test-params))
+          run:
+            path: ((build-test-cmd))
+            args: ((build-test-args))
+
+      - in_parallel:
+          - task: clamav-scan
+            file: common-pipelines/container/clamav-scan.yml
+            image: image
+
+          - task: usg-audit
+            file: common-pipelines/container/usg-audit.yml
+            image: image
+            params:
+              IMAGENAME: ((image-repository))
+              TAILORINGFILE: ((tailoring-file))
+
+          - task: scan-image
+            file: common-pipelines/container/scan-image.yml
+            params:
+              IMAGENAME: ((image-repository))
+              GRYPEPATH: ((grype-path))
+
+      - task: cve-check
+        file: common-pipelines/container/cve-check.yml
+
+      - in_parallel:
+          - task: software-inventory
+            file: common-pipelines/container/software-inventory.yml
+            image: image
+
+          - put: image
+            inputs:
+              - image
+              - src
+            no_get: true
+            params:
+              image: image/image.tar
+              tag: staging
+
+    on_failure:
+      put: slack
+      params:
+        text: |
+          :warning: Pipeline `$BUILD_PIPELINE_NAME` STAGING build FAILED
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: ((slack-channel))
+        username: ((slack-username))
+        icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
+
   - name: main
     serial_groups: [container-scans]
     plan:
       - in_parallel:
           - get: src
             trigger: ((src-trigger))
+            passed: [staging]
 
           - get: base-image
             trigger: true
+            passed: [staging]
             params:
               format: oci
 

--- a/container/pipeline-pages.yml
+++ b/container/pipeline-pages.yml
@@ -127,14 +127,13 @@ jobs:
             file: common-pipelines/container/software-inventory.yml
             image: image
 
-          - put: image
+          - put: staging-image
             inputs:
               - image
               - src
             no_get: true
             params:
               image: image/image.tar
-              tag: staging
 
     on_failure:
       put: slack
@@ -355,6 +354,15 @@ resources:
       aws_secret_access_key: ((ecr_aws_secret))
       repository: ((image-repository))
       tag: latest
+      aws_region: us-gov-west-1
+
+  - name: staging-image
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: ((image-repository))
+      tag: staging
       aws_region: us-gov-west-1
 
   - name: slack


### PR DESCRIPTION
## Changes proposed in this pull request:

- This adds a staging job to all of our container pipelines
- This creates staging images that we can then use for testing changes before moving them to production

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Adding a staging job will improve security by allowing us to test changes quickly and without impacting production.

Co-authored-by: OpenCode Agent <david.n.anderson@gsa.gov>