### PR TITLE
fix base and external pipelines to work with staging images

### DIFF
--- a/container/pipeline-base.yml
+++ b/container/pipeline-base.yml
@@ -105,6 +105,9 @@ jobs:
             params:
               format: oci
 
+          - get: weekly-rebuild
+            trigger: true
+
           - get: common-pipelines
 
           - get: common-dockerfiles
@@ -113,28 +116,6 @@ jobs:
         privileged: true
         file: common-pipelines/container/oci-build.yml
         params: ((oci-build-params))
-
-      - task: build-test
-        privileged: true
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              aws_access_key_id: ((ecr_aws_key))
-              aws_secret_access_key: ((ecr_aws_secret))
-              repository: oci-build-task
-              aws_region: us-gov-west-1
-              tag: latest
-          inputs:
-            - name: src
-            - name: base-image
-            - name: common-pipelines
-            - name: common-dockerfiles
-          params: ((build-test-params))
-          run:
-            path: ((build-test-cmd))
-            args: ((build-test-args))
 
       - in_parallel:
           - task: clamav-scan
@@ -186,17 +167,16 @@ jobs:
     plan:
       - in_parallel:
           - get: src
-            trigger: ((src-trigger))
-            passed: [staging]
+          # trigger: true
 
           - get: base-image
-            trigger: true
-            passed: [staging]
+            # trigger: true
             params:
               format: oci
 
           - get: weekly-rebuild
             trigger: true
+            passed: [staging]
 
           - get: common-pipelines
             trigger: ((common-pipelines-trigger))

--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -5,9 +5,11 @@ jobs:
       - in_parallel:
           - get: src
             trigger: ((src-trigger))
+            passed: [staging]
 
           - get: base-image
             trigger: true
+            passed: [staging]
             params:
               format: oci
 
@@ -104,6 +106,44 @@ jobs:
         username: ((slack-username))
         icon_url: ((slack-icon-url))
 
+  - name: continuous-scan
+    serial_groups: [container-scans]
+    plan:
+      - in_parallel:
+          - get: image
+            trigger: false
+            params:
+              format: oci
+
+          - get: common-pipelines
+            trigger: false
+
+          - get: daily
+            trigger: true
+
+      - task: scan-image
+        file: common-pipelines/container/scan-image.yml
+        params:
+          IMAGENAME: ((image-repository))
+          GRYPEPATH: ((grype-path))
+
+      - in_parallel:
+          - task: cve-check
+            file: common-pipelines/container/cve-check.yml
+
+          - task: import-scan
+            file: common-pipelines/container/import-scan.yml
+            params:
+              IMAGENAME: ((image-repository))
+
+    on_failure:
+      put: slack
+      params:
+        <<: *slack-failure-params
+        text: |
+          :x: Continuous Scan of `$BUILD_PIPELINE_NAME` FAILED
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>0
+
   - name: staging
     serial_groups: [container-scans]
     plan:
@@ -190,149 +230,6 @@ jobs:
         channel: ((slack-channel-notifications))
         username: ((slack-username))
         icon_url: ((slack-icon-url))
-
-  - name: main
-    serial_groups: [container-scans]
-    plan:
-      - in_parallel:
-          - get: src
-            trigger: ((src-trigger))
-            passed: [staging]
-
-          - get: base-image
-            trigger: true
-            passed: [staging]
-            params:
-              format: oci
-
-          - get: common-pipelines
-            # trigger: ((common-pipelines-trigger))
-
-          - get: common-dockerfiles
-            # trigger: ((dockerfile-trigger))
-
-      - task: oci-build
-        privileged: true
-        file: common-pipelines/container/oci-build.yml
-        params: ((oci-build-params)) # for available params, see https://github.com/concourse/oci-build-task#params
-
-      - task: build-test
-        privileged: true
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              aws_access_key_id: ((ecr_aws_key))
-              aws_secret_access_key: ((ecr_aws_secret))
-              repository: oci-build-task
-              aws_region: us-gov-west-1
-              tag: latest
-          inputs:
-            - name: src
-            - name: base-image
-            - name: common-pipelines
-            - name: common-dockerfiles
-          params: ((build-test-params))
-          run:
-            path: ((build-test-cmd))
-            args: ((build-test-args))
-
-      - in_parallel:
-          - task: clamav-scan
-            file: common-pipelines/container/clamav-scan.yml
-            image: image
-
-          - task: usg-audit
-            file: common-pipelines/container/usg-audit.yml
-            image: image
-            params:
-              IMAGENAME: ((image-repository))
-              TAILORINGFILE: ((tailoring-file))
-
-          - task: scan-image
-            file: common-pipelines/container/scan-image.yml
-            params:
-              IMAGENAME: ((image-repository))
-              GRYPEPATH: ((grype-path))
-
-      - task: cve-check
-        file: common-pipelines/container/cve-check.yml
-
-      - in_parallel:
-          - task: import-scan
-            file: common-pipelines/container/import-scan.yml
-            params:
-              IMAGENAME: ((image-repository))
-
-          - task: software-inventory
-            file: common-pipelines/container/software-inventory.yml
-            image: image
-
-          - put: audit-xml-file
-            no_get: true
-            params:
-              file: audit/((image-repository))-audit.xml
-
-          - put: audit-html-file
-            no_get: true
-            params:
-              file: audit/((image-repository))-audit.html
-
-          - put: image
-            inputs:
-              - image
-              - src
-            no_get: true
-            params:
-              image: image/image.tar
-              additional_tags: src/.git/short_ref
-
-    on_failure:
-      put: slack
-      params:
-        <<: *slack-failure-params
-        text: |
-          :x: Pipeline `$BUILD_PIPELINE_NAME` FAILED to upload image to ECR
-          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-
-  - name: continuous-scan
-    serial_groups: [container-scans]
-    plan:
-      - in_parallel:
-          - get: image
-            trigger: false
-            params:
-              format: oci
-
-          - get: common-pipelines
-            trigger: false
-
-          - get: daily
-            trigger: true
-
-      - task: scan-image
-        file: common-pipelines/container/scan-image.yml
-        params:
-          IMAGENAME: ((image-repository))
-          GRYPEPATH: ((grype-path))
-
-      - in_parallel:
-          - task: cve-check
-            file: common-pipelines/container/cve-check.yml
-
-          - task: import-scan
-            file: common-pipelines/container/import-scan.yml
-            params:
-              IMAGENAME: ((image-repository))
-
-    on_failure:
-      put: slack
-      params:
-        <<: *slack-failure-params
-        text: |
-          :x: Continuous Scan of `$BUILD_PIPELINE_NAME` FAILED
-          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>0
 
   - name: conmon-scan
     serial_groups: [container-scans]


### PR DESCRIPTION
## Changes proposed in this pull request:

- Need to update the base and external pipelines to work with the staging image jobs because the pipelines operate slightly different

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing the staging image job for the base and external pipelines
