### PR TITLE
fix integration variables

### DIFF
--- a/container/integration-test.yml
+++ b/container/integration-test.yml
@@ -23,7 +23,6 @@ params:
   INTEGRATION_TEST_ARGS: "No integration test configured"
   ENABLE_CONCOURSE_VALIDATION: "false"
   IMAGE_TYPE: generic
-  IMAGE_REPOSITORY: ((image-repository))
 
 run:
   path: common-pipelines/container/integration-test.sh

--- a/container/pipeline-base.yml
+++ b/container/pipeline-base.yml
@@ -188,6 +188,7 @@ jobs:
           INTEGRATION_TEST_ARGS: ((integration-test-args))
           ENABLE_CONCOURSE_VALIDATION: ((enable-concourse-validation))
           IMAGE_TYPE: ((image-type))
+          IMAGE_REPOSITORY: ((image-repository))
 
     on_failure:
       put: slack

--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -254,6 +254,7 @@ jobs:
           INTEGRATION_TEST_ARGS: ((integration-test-args))
           ENABLE_CONCOURSE_VALIDATION: ((enable-concourse-validation))
           IMAGE_TYPE: ((image-type))
+          IMAGE_REPOSITORY: ((image-repository))
 
     on_failure:
       put: slack

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -227,6 +227,7 @@ jobs:
           INTEGRATION_TEST_ARGS: ((integration-test-args))
           ENABLE_CONCOURSE_VALIDATION: ((enable-concourse-validation))
           IMAGE_TYPE: ((image-type))
+          IMAGE_REPOSITORY: ((image-repository))
 
     on_failure:
       put: slack

--- a/container/pipeline-pages.yml
+++ b/container/pipeline-pages.yml
@@ -167,6 +167,7 @@ jobs:
           INTEGRATION_TEST_ARGS: ((integration-test-args))
           ENABLE_CONCOURSE_VALIDATION: ((enable-concourse-validation))
           IMAGE_TYPE: ((image-type))
+          IMAGE_REPOSITORY: ((image-repository))
 
     on_failure:
       put: slack


### PR DESCRIPTION
## Changes proposed in this pull request:

- Move the location of where the image-repository variable is set so it can be read correctly

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Fixing location of image-repository variable
