### PR TITLE
set staging image to be used by task

### DIFF
--- a/container/integration-test.yml
+++ b/container/integration-test.yml
@@ -4,15 +4,6 @@
 
 platform: linux
 
-image_resource:
-  type: registry-image
-  source:
-    aws_access_key_id: ((ecr_aws_key))
-    aws_secret_access_key: ((ecr_aws_secret))
-    repository: ((image-repository))
-    tag: staging
-    aws_region: us-gov-west-1
-
 inputs:
   - name: common-pipelines
   - name: src

--- a/container/pipeline-base.yml
+++ b/container/pipeline-base.yml
@@ -181,8 +181,11 @@ jobs:
           - get: common-pipelines
             passed: [staging]
 
+          - get: staging-image
+
       - task: integration-test
         file: common-pipelines/container/integration-test.yml
+        image: staging-image
         params:
           INTEGRATION_TEST_CMD: ((integration-test-cmd))
           INTEGRATION_TEST_ARGS: ((integration-test-args))

--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -247,8 +247,11 @@ jobs:
           - get: common-pipelines
             passed: [staging]
 
+          - get: staging-image
+
       - task: integration-test
         file: common-pipelines/container/integration-test.yml
+        image: staging-image
         params:
           INTEGRATION_TEST_CMD: ((integration-test-cmd))
           INTEGRATION_TEST_ARGS: ((integration-test-args))

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -220,8 +220,11 @@ jobs:
           - get: common-pipelines
             passed: [staging]
 
+          - get: staging-image
+
       - task: integration-test
         file: common-pipelines/container/integration-test.yml
+        image: staging-image
         params:
           INTEGRATION_TEST_CMD: ((integration-test-cmd))
           INTEGRATION_TEST_ARGS: ((integration-test-args))

--- a/container/pipeline-pages.yml
+++ b/container/pipeline-pages.yml
@@ -160,8 +160,11 @@ jobs:
           - get: common-pipelines
             passed: [staging]
 
+          - get: staging-image
+
       - task: integration-test
         file: common-pipelines/container/integration-test.yml
+        image: staging-image
         params:
           INTEGRATION_TEST_CMD: ((integration-test-cmd))
           INTEGRATION_TEST_ARGS: ((integration-test-args))


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updates the integration-test task to set the staging image in the pipeline file, rather than in the integration-test.yml file

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just updating the way the staging image is set
