### PR TITLE
fix: use real Concourse layout in integration tests

### DIFF
--- a/container/concourse-tests/README.md
+++ b/container/concourse-tests/README.md
@@ -5,10 +5,26 @@ This directory contains validation scripts that test images in Concourse-like ex
 ## Purpose
 
 These tests simulate how Concourse runs containers:
-- Workspace directory structures (`/tmp/build/workspace/`)
-- Volume mounting behavior (separate input/output directories)
+- The real task working directory, where Concourse mounts each declared
+  input/output in its own subdirectory
+- A writable scratch workspace exposed via the `$CONCOURSE_WORKSPACE`
+  environment variable (set by `integration-test.sh`)
 - Resource protocol compliance (stdin/stdout JSON for resources)
 - Typical task operations (git clone, builds, deployments)
+
+## Workspace Convention
+
+`integration-test.sh` creates a real temporary directory (via `mktemp -d`),
+exports it as `CONCOURSE_WORKSPACE`, and cleans it up on exit. Each test
+script MUST use `$CONCOURSE_WORKSPACE` rather than hardcoding a path. For
+standalone runs, scripts fall back to their own `mktemp -d` if the variable is
+unset:
+
+```bash
+: "${CONCOURSE_WORKSPACE:=$(mktemp -d)}"
+mkdir -p "$CONCOURSE_WORKSPACE"
+cd "$CONCOURSE_WORKSPACE"
+```
 
 ## When Tests Run
 
@@ -34,20 +50,26 @@ set -e  # Exit on first error
 
 echo "  → Testing <image-name> in Concourse context"
 
+# Use the scratch workspace provided by integration-test.sh (fall back to a
+# temp dir when run standalone).
+: "${CONCOURSE_WORKSPACE:=$(mktemp -d)}"
+mkdir -p "$CONCOURSE_WORKSPACE"
+cd "$CONCOURSE_WORKSPACE"
+
 # Test 1: Resource-specific functionality
 # For resources: test check/in/out protocol
 # For task images: test typical operations
 
 # Example for resources:
-cat > /tmp/build/workspace/test-input.json <<EOF
+cat > "$CONCOURSE_WORKSPACE/test-input.json" <<EOF
 {"source":{},"version":{}}
 EOF
 
-/opt/resource/check < /tmp/build/workspace/test-input.json | jq -e 'type == "array"'
+/opt/resource/check < "$CONCOURSE_WORKSPACE/test-input.json" | jq -e 'type == "array"'
 echo "  ✓ Resource check returns JSON array"
 
 # Example for task images:
-git clone https://github.com/cloud-gov/example.git /tmp/build/workspace/src/repo
+git clone https://github.com/cloud-gov/example.git "$CONCOURSE_WORKSPACE/src/repo"
 echo "  ✓ Git operations work"
 
 echo "  ✓ <image-name> Concourse validation passed"
@@ -64,7 +86,6 @@ chmod +x container/concourse-tests/<image-type>.sh
 ```bash
 docker run --rm \
   -v $(pwd):/workspace \
-  -w /tmp/build/workspace \
   <image>:staging \
   /workspace/container/concourse-tests/<image-type>.sh
 ```
@@ -111,8 +132,9 @@ done
 
 ### Pattern 3: Workspace Operations
 ```bash
-# Test file operations in workspace
-cd /tmp/build/workspace
+# Test file operations in the scratch workspace
+cd "$CONCOURSE_WORKSPACE"
+mkdir -p src output
 echo "test" > src/file.txt
 cat src/file.txt > output/result.txt
 [ -f output/result.txt ] && echo "  ✓ Workspace operations work"
@@ -122,7 +144,7 @@ cat src/file.txt > output/result.txt
 
 ### Test fails locally but passes in pipeline
 - Check that you're using the `:staging` tag
-- Verify working directory matches pipeline (`/tmp/build/workspace`)
+- Ensure `$CONCOURSE_WORKSPACE` resolves (scripts fall back to `mktemp -d`)
 
 ### Test passes but real Concourse task fails
 - Check for external dependencies (network, credentials)

--- a/container/concourse-tests/general-task.sh
+++ b/container/concourse-tests/general-task.sh
@@ -3,7 +3,11 @@ set -e
 
 echo "  → Testing general-task in Concourse context"
 
-cd /tmp/build/workspace
+# Scratch workspace provided by integration-test.sh; fall back to a temp dir
+# when run standalone.
+: "${CONCOURSE_WORKSPACE:=$(mktemp -d)}"
+mkdir -p "$CONCOURSE_WORKSPACE"
+cd "$CONCOURSE_WORKSPACE"
 
 # Test 1: Critical CLI tools
 echo "  → Testing critical CLI tools"
@@ -35,7 +39,7 @@ cf api --version >/dev/null 2>&1 && echo "  ✓ CF CLI works"
 
 # Test 4: Terraform
 echo "  → Testing Terraform"
-cd /tmp/build/workspace
+cd "$CONCOURSE_WORKSPACE"
 cat > src/test.tf <<EOF
 variable "test" {
   default = "value"

--- a/container/concourse-tests/github-pr-resource.sh
+++ b/container/concourse-tests/github-pr-resource.sh
@@ -3,7 +3,11 @@ set -e
 
 echo "  → Testing github-pr-resource in Concourse context"
 
-cd /tmp/build/workspace
+# Scratch workspace provided by integration-test.sh; fall back to a temp dir
+# when run standalone.
+: "${CONCOURSE_WORKSPACE:=$(mktemp -d)}"
+mkdir -p "$CONCOURSE_WORKSPACE"
+cd "$CONCOURSE_WORKSPACE"
 
 # Test 1: Check script protocol
 echo "  → Testing /opt/resource/check protocol"

--- a/container/concourse-tests/github-release-resource.sh
+++ b/container/concourse-tests/github-release-resource.sh
@@ -3,7 +3,11 @@ set -e
 
 echo "  → Testing github-release-resource in Concourse context"
 
-cd /tmp/build/workspace
+# Scratch workspace provided by integration-test.sh; fall back to a temp dir
+# when run standalone.
+: "${CONCOURSE_WORKSPACE:=$(mktemp -d)}"
+mkdir -p "$CONCOURSE_WORKSPACE"
+cd "$CONCOURSE_WORKSPACE"
 
 # Test 1: Check script protocol
 echo "  → Testing /opt/resource/check protocol"

--- a/container/concourse-tests/nginx.sh
+++ b/container/concourse-tests/nginx.sh
@@ -3,7 +3,11 @@ set -e
 
 echo "  → Testing Nginx image in Concourse context"
 
-cd /tmp/build/workspace
+# Scratch workspace provided by integration-test.sh; fall back to a temp dir
+# when run standalone.
+: "${CONCOURSE_WORKSPACE:=$(mktemp -d)}"
+mkdir -p "$CONCOURSE_WORKSPACE"
+cd "$CONCOURSE_WORKSPACE"
 
 # Test 1: nginx binary
 echo "  → Testing nginx binary"

--- a/container/concourse-tests/node.sh
+++ b/container/concourse-tests/node.sh
@@ -3,7 +3,11 @@ set -e
 
 echo "  → Testing Node image in Concourse context"
 
-cd /tmp/build/workspace
+# Scratch workspace provided by integration-test.sh; fall back to a temp dir
+# when run standalone.
+: "${CONCOURSE_WORKSPACE:=$(mktemp -d)}"
+mkdir -p "$CONCOURSE_WORKSPACE"
+cd "$CONCOURSE_WORKSPACE"
 
 # Test 1: Node and npm versions
 echo "  → Testing Node.js and npm"
@@ -12,6 +16,7 @@ npm --version >/dev/null && echo "  ✓ npm available ($(npm --version))"
 
 # Test 2: npm install (common Concourse operation)
 echo "  → Testing npm install"
+mkdir -p "$CONCOURSE_WORKSPACE/output"
 mkdir -p src/app
 cd src/app
 cat > package.json <<EOF
@@ -20,7 +25,7 @@ cat > package.json <<EOF
   "version": "1.0.0",
   "scripts": {
     "test": "echo 'Tests passed'",
-    "build": "echo 'Build complete' > ../../output/dist.tar.gz"
+    "build": "echo 'Build complete' > \"$CONCOURSE_WORKSPACE/output/dist.tar.gz\""
   },
   "dependencies": {
     "express": "^4.18.0"
@@ -33,9 +38,8 @@ npm install --quiet >/dev/null 2>&1 && echo "  ✓ npm install works"
 # Test 3: npm scripts (test/build)
 echo "  → Testing npm scripts"
 npm test >/dev/null 2>&1 && echo "  ✓ npm test works"
-mkdir -p ../../output
 npm run build >/dev/null 2>&1
-[ -f ../../output/dist.tar.gz ] && echo "  ✓ npm build creates artifacts"
+[ -f "$CONCOURSE_WORKSPACE/output/dist.tar.gz" ] && echo "  ✓ npm build creates artifacts"
 
 # Test 4: Node execution
 echo "  → Testing Node execution"
@@ -43,8 +47,8 @@ node -e "const express = require('express'); console.log('Module loading works')
   echo "  ✓ Node can load installed modules"
 
 # Test 5: Workspace structure (typical Concourse setup)
-cd /tmp/build/workspace
-[ -d src ] && echo "  ✓ src directory exists (input mount)"
-[ -d output ] && echo "  ✓ output directory exists (output mount)"
+cd "$CONCOURSE_WORKSPACE"
+[ -d src ] && echo "  ✓ src directory exists"
+[ -d output ] && echo "  ✓ output directory exists"
 
 echo "  ✓ Node image Concourse validation passed"

--- a/container/concourse-tests/oci-build-task.sh
+++ b/container/concourse-tests/oci-build-task.sh
@@ -3,7 +3,11 @@ set -e
 
 echo "  → Testing oci-build-task in Concourse context"
 
-cd /tmp/build/workspace
+# Scratch workspace provided by integration-test.sh; fall back to a temp dir
+# when run standalone.
+: "${CONCOURSE_WORKSPACE:=$(mktemp -d)}"
+mkdir -p "$CONCOURSE_WORKSPACE"
+cd "$CONCOURSE_WORKSPACE"
 
 # Test 1: buildkit command available
 echo "  → Testing buildkit availability"

--- a/container/concourse-tests/python.sh
+++ b/container/concourse-tests/python.sh
@@ -3,7 +3,11 @@ set -e
 
 echo "  → Testing Python image in Concourse context"
 
-cd /tmp/build/workspace
+# Scratch workspace provided by integration-test.sh; fall back to a temp dir
+# when run standalone.
+: "${CONCOURSE_WORKSPACE:=$(mktemp -d)}"
+mkdir -p "$CONCOURSE_WORKSPACE"
+cd "$CONCOURSE_WORKSPACE"
 
 # Test 1: Python and pip versions
 echo "  → Testing Python and pip"
@@ -27,7 +31,7 @@ python3 -c "import requests; print('Module loading works')" >/dev/null 2>&1 && \
 
 # Test 4: Virtual environment (common pattern)
 echo "  → Testing virtual environment"
-cd /tmp/build/workspace/src
+cd "$CONCOURSE_WORKSPACE/src"
 python3 -m venv test-venv >/dev/null 2>&1
 . test-venv/bin/activate
 pip install --quiet requests >/dev/null 2>&1
@@ -35,8 +39,8 @@ python -c "import requests" >/dev/null 2>&1 && echo "  ✓ Virtual environment w
 deactivate
 
 # Test 5: Output artifacts
-mkdir -p /tmp/build/workspace/output
-echo "build-complete" > /tmp/build/workspace/output/result.txt
-[ -f /tmp/build/workspace/output/result.txt ] && echo "  ✓ Output artifacts work"
+mkdir -p "$CONCOURSE_WORKSPACE/output"
+echo "build-complete" > "$CONCOURSE_WORKSPACE/output/result.txt"
+[ -f "$CONCOURSE_WORKSPACE/output/result.txt" ] && echo "  ✓ Output artifacts work"
 
 echo "  ✓ Python image Concourse validation passed"

--- a/container/concourse-tests/s3-resource.sh
+++ b/container/concourse-tests/s3-resource.sh
@@ -3,7 +3,11 @@ set -e
 
 echo "  → Testing s3-resource in Concourse context"
 
-cd /tmp/build/workspace
+# Scratch workspace provided by integration-test.sh; fall back to a temp dir
+# when run standalone.
+: "${CONCOURSE_WORKSPACE:=$(mktemp -d)}"
+mkdir -p "$CONCOURSE_WORKSPACE"
+cd "$CONCOURSE_WORKSPACE"
 
 # Test 1: Check script protocol
 echo "  → Testing /opt/resource/check protocol"

--- a/container/concourse-tests/slack-notification-resource.sh
+++ b/container/concourse-tests/slack-notification-resource.sh
@@ -3,7 +3,11 @@ set -e
 
 echo "  → Testing slack-notification-resource in Concourse context"
 
-cd /tmp/build/workspace
+# Scratch workspace provided by integration-test.sh; fall back to a temp dir
+# when run standalone.
+: "${CONCOURSE_WORKSPACE:=$(mktemp -d)}"
+mkdir -p "$CONCOURSE_WORKSPACE"
+cd "$CONCOURSE_WORKSPACE"
 
 # Test 1: Check script protocol (Slack notification doesn't implement check)
 echo "  → Testing /opt/resource/check protocol"

--- a/container/integration-test.sh
+++ b/container/integration-test.sh
@@ -4,6 +4,10 @@ set -e
 # Integration Test Script
 # Runs standard integration tests and optional Concourse context validation
 
+# Resolve this script's directory so paths are independent of the current
+# working directory (do NOT rely on cd-ing into the workspace).
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 echo "=== Integration Test: Starting ==="
 echo "Image: ${IMAGE_REPOSITORY}:staging"
 echo ""
@@ -22,34 +26,56 @@ echo ""
 if [ "$ENABLE_CONCOURSE_VALIDATION" = "true" ]; then
   echo "=== Concourse Context Validation: Starting ==="
   echo ""
-  
-  # Create Concourse-like workspace structure
-  echo "→ Setting up Concourse-like workspace"
-  mkdir -p /tmp/build/workspace/{src,output,artifacts}
-  cd /tmp/build/workspace
-  echo "  ✓ Workspace structure created"
+
+  # When Concourse runs this task it places each declared input/output in its
+  # own directory under the task working directory (see integration-test.yml:
+  # inputs common-pipelines, src). We validate from that real working directory
+  # rather than fabricating a /tmp/build/workspace tree.
+  CONCOURSE_WORKDIR="$(pwd)"
+  echo "→ Concourse task working directory"
+  echo "  ℹ $CONCOURSE_WORKDIR"
+  for input in common-pipelines src; do
+    if [ -d "$CONCOURSE_WORKDIR/$input" ]; then
+      echo "  ✓ Input '$input' present (mounted by Concourse)"
+    fi
+  done
   echo ""
-  
-  # Test running as non-root (Concourse behavior)
+
+  # Provide a writable scratch workspace for the per-image tests. Child scripts
+  # use $CONCOURSE_WORKSPACE; we create a real temp dir and clean it up on exit.
+  echo "→ Setting up scratch workspace"
+  CONCOURSE_WORKSPACE="$(mktemp -d)"
+  export CONCOURSE_WORKSPACE
+  mkdir -p "$CONCOURSE_WORKSPACE"/{src,output}
+  trap 'rm -rf "$CONCOURSE_WORKSPACE"' EXIT
+  echo "  ✓ Scratch workspace: $CONCOURSE_WORKSPACE"
+  echo ""
+
+  # Report the image's default user context.
+  # Concourse runs a task as the image's default USER unless the task sets
+  # run.user or privileged. It does NOT force non-root; many of these images
+  # run as root by default.
   echo "→ Checking user context"
+  echo "  ℹ Image default user: UID $(id -u) ($(id -un 2>/dev/null || echo unknown))"
   if [ "$(id -u)" = "0" ]; then
-    echo "  ⚠ Running as root (UID 0)"
-    echo "  Note: Concourse typically runs tasks as non-root"
+    echo "  ℹ Running as root — Concourse will run this image as root unless the"
+    echo "    task sets run.user. This is common for these images."
   else
-    echo "  ✓ Running as non-root user (UID $(id -u))"
+    echo "  ℹ Running as non-root (UID $(id -u)) — set via the image Dockerfile USER."
   fi
   echo ""
-  
-  # Test filesystem operations (volume mounts)
+
+  # Verify the scratch workspace is writable (inputs/outputs are writable in
+  # Concourse task containers).
   echo "→ Testing filesystem operations"
-  touch src/test-write.txt && rm src/test-write.txt && \
-    echo "  ✓ Can write to src directory (input mount simulation)"
-  touch output/test-output.txt && \
-    echo "  ✓ Can write to output directory (output mount simulation)"
+  touch "$CONCOURSE_WORKSPACE/src/test-write.txt" && rm "$CONCOURSE_WORKSPACE/src/test-write.txt" && \
+    echo "  ✓ Can write to src directory"
+  touch "$CONCOURSE_WORKSPACE/output/test-output.txt" && \
+    echo "  ✓ Can write to output directory"
   echo ""
   
   # Run image-specific Concourse tests
-  CONCOURSE_TEST_SCRIPT="common-pipelines/container/concourse-tests/${IMAGE_TYPE}.sh"
+  CONCOURSE_TEST_SCRIPT="$SCRIPT_DIR/concourse-tests/${IMAGE_TYPE}.sh"
   if [ -f "$CONCOURSE_TEST_SCRIPT" ]; then
     echo "→ Running Concourse-specific tests for '${IMAGE_TYPE}'"
     chmod +x "$CONCOURSE_TEST_SCRIPT"


### PR DESCRIPTION
The integration test script fabricated a /tmp/build/workspace tree and cd'd into it before resolving the per-image concourse test script via a relative path, so the script was never found when validation ran.

- Resolve the concourse test script via the script's own directory so the lookup no longer depends on the current working directory.
- Validate from Concourse's real task working directory and confirm declared inputs are present, instead of building a fake workspace.
- Provide a cleaned-up scratch workspace via mktemp, exported as CONCOURSE_WORKSPACE, and update all 9 per-image test scripts to use it (with a standalone mktemp fallback).
- Correct the misleading non-root user-context check to an accurate, informational report of the image's default user.
- Update concourse-tests/README.md to document the new convention.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Updating integration tests to more accurately reflect what needs to be tested will make our images overall more secure.
