### PR TITLE
remove node-v20 image

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ flowchart LR
 
     subgraph Pages Concourse Team
         pages -->|sets| pages-dind-v25["image-dind-v25 pipeline"]
-        pages -->|sets| pages-node-v20["image-node-v20 pipeline"]
         pages -->|sets| pages-node-v22["image-node-v22 pipeline"]
         pages -->|sets| pages-node-v24["image-node-v24 pipeline"]
         pages -->|sets| pages-python-v3["image-python-v3.11 pipeline"]

--- a/ci/container/pages/node-v20/vars.yml
+++ b/ci/container/pages/node-v20/vars.yml
@@ -1,5 +1,0 @@
-image-repository: pages-node-v20
-oci-build-params: { CONTEXT: src/node/v20 }
-src-repo: cloud-gov/pages-images
-src-repo-uri: https://github.com/cloud-gov/pages-images
-src-path: [node/v20/*]

--- a/ci/container/pipeline.yml
+++ b/ci/container/pipeline.yml
@@ -102,7 +102,6 @@ jobs:
           - var: name # repo, pipeline, and image name; all the same.
             values:
               - dind
-              - node-v20
               - node-v22
               - node-v24
               - python-v3.11


### PR DESCRIPTION
## Changes proposed in this pull request:

- Removes node-v20 from our image building pipelines

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Node v20 is EOL