### PR TITLE
update openresty version and add ssl patch

### DIFF
--- a/container/dockerfiles/openresty/Dockerfile
+++ b/container/dockerfiles/openresty/Dockerfile
@@ -6,7 +6,7 @@ ARG base_image
 FROM ${base_image}
 
 # Docker Build Arguments
-ARG RESTY_VERSION="1.29.2.3"
+ARG RESTY_VERSION="1.31.1.1"
 ARG RESTY_LUAROCKS_VERSION="3.13.0"
 
 # https://github.com/openresty/openresty-packaging/blob/master/deb/openresty-openssl3/debian/rules
@@ -141,7 +141,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     fi \
     && if [ $(echo ${RESTY_OPENSSL_VERSION} | cut -c 1-5) = "1.1.0" ] ; then \
     echo 'patching OpenSSL 1.1.0 for OpenResty' \
-    && curl -s https://raw.githubusercontent.com/openresty/openresty/ed328977028c3ec3033bc25873ee360056e247cd/patches/openssl-1.1.0j-parallel_build_fix.patch | patch -p1 \
+    && curl -s https://raw.githubusercontent.com/openresty/openresty/master/patches/openssl-1.1.0j-parallel_build_fix.patch | patch -p1 \
     && curl -s https://raw.githubusercontent.com/openresty/openresty/master/patches/openssl-${RESTY_OPENSSL_PATCH_VERSION}-sess_set_get_cb_yield.patch | patch -p1 ; \
     fi \
     && ./config \


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updates to the latest openresty version
- Updates the path for the ssl patch

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Updates to incorporate security patches
