### PR TITLE
disable git resource test

### DIFF
--- a/ci/container/external/git-resource/vars.yml
+++ b/ci/container/external/git-resource/vars.yml
@@ -7,3 +7,4 @@ src-source:
   # Since src is a repo outside the cloud-gov org, don't verify commits.
 dockerfile-path: ["container/dockerfiles/git-resource/Dockerfile"]
 dockerfile-trigger: true
+enable-concourse-validation: "false"


### PR DESCRIPTION
## Changes proposed in this pull request:

- Disable the git concourse resource for now

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Just disabling this test temporarily until we can fix it
