### PR TITLE
switch back to using latest oci-build image

### DIFF
--- a/container/oci-build.yml
+++ b/container/oci-build.yml
@@ -8,7 +8,7 @@ image_resource:
     aws_secret_access_key: ((ecr_aws_secret))
     repository: oci-build-task
     aws_region: us-gov-west-1
-    tag: staging
+    tag: latest
 
 caches:
   - path: cache

--- a/container/pipeline-external.yml
+++ b/container/pipeline-external.yml
@@ -35,7 +35,7 @@ jobs:
               aws_secret_access_key: ((ecr_aws_secret))
               repository: oci-build-task
               aws_region: us-gov-west-1
-              tag: staging
+              tag: latest
           inputs:
             - name: src
             - name: base-image
@@ -176,7 +176,7 @@ jobs:
               aws_secret_access_key: ((ecr_aws_secret))
               repository: oci-build-task
               aws_region: us-gov-west-1
-              tag: staging
+              tag: latest
           inputs:
             - name: src
             - name: base-image

--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -63,7 +63,7 @@ jobs:
               aws_secret_access_key: ((ecr_aws_secret))
               repository: oci-build-task
               aws_region: us-gov-west-1
-              tag: staging
+              tag: latest
           inputs:
             - name: src
             - name: base-image
@@ -149,7 +149,7 @@ jobs:
               aws_secret_access_key: ((ecr_aws_secret))
               repository: oci-build-task
               aws_region: us-gov-west-1
-              tag: staging
+              tag: latest
           inputs:
             - name: src
             - name: base-image


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update the pipelines to use latest again for the oci-build image

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, switching back to using latest image
