### PR TITLE
moving tag back to latest

### DIFF
--- a/container/pipeline-internal.yml
+++ b/container/pipeline-internal.yml
@@ -280,7 +280,7 @@ jobs:
               aws_secret_access_key: ((ecr_aws_secret))
               repository: oci-build-task
               aws_region: us-gov-west-1
-              tag: staging
+              tag: latest
           inputs:
             - name: src
             - name: base-image


### PR DESCRIPTION
## Changes proposed in this pull request:

- This moves the image used for the build-test of the main job back to using the latest tag

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just moving image back to using latest tag instead of staging