### PR TITLE
turns off concourse integration tests

### DIFF
--- a/ci/container/external/bosh-io-stemcell-resource/vars.yml
+++ b/ci/container/external/bosh-io-stemcell-resource/vars.yml
@@ -9,3 +9,4 @@ build-test-params:
   TARGET: tests
   IMAGE_ARG_base_image: base-image/image.tar
   CONTEXT: src
+enable-concourse-validation: "false"

--- a/ci/container/external/email-resource/vars.yml
+++ b/ci/container/external/email-resource/vars.yml
@@ -14,3 +14,4 @@ build-test-params:
   TARGET: tests
   IMAGE_ARG_base_image: base-image/image.tar
   CONTEXT: src
+enable-concourse-validation: "false"

--- a/ci/container/external/pool-resource/vars.yml
+++ b/ci/container/external/pool-resource/vars.yml
@@ -14,3 +14,4 @@ build-test-params:
   TARGET: tests
   IMAGE_ARG_base_image: base-image/image.tar
   CONTEXT: src
+enable-concourse-validation: "false"

--- a/ci/container/external/registry-image-resource/vars.yml
+++ b/ci/container/external/registry-image-resource/vars.yml
@@ -14,3 +14,4 @@ build-test-params:
   TARGET: tests
   IMAGE_ARG_base_image: base-image/image.tar
   CONTEXT: src
+enable-concourse-validation: "false"

--- a/ci/container/external/semver-resource/vars.yml
+++ b/ci/container/external/semver-resource/vars.yml
@@ -14,3 +14,4 @@ build-test-params:
   TARGET: tests
   IMAGE_ARG_base_image: base-image/image.tar
   CONTEXT: src
+enable-concourse-validation: "false"

--- a/ci/container/external/time-resource/vars.yml
+++ b/ci/container/external/time-resource/vars.yml
@@ -14,3 +14,4 @@ build-test-params:
   TARGET: tests
   IMAGE_ARG_base_image: base-image/image.tar
   CONTEXT: src
+enable-concourse-validation: "false"

--- a/ci/container/internal/clamav-rest-candidate/vars.yml
+++ b/ci/container/internal/clamav-rest-candidate/vars.yml
@@ -5,3 +5,4 @@ oci-build-params:
 src-repo: cloud-gov/clamav-rest-image
 src-repo-uri: https://github.com/cloud-gov/clamav-rest-image
 src-branch: main
+enable-concourse-validation: "false"

--- a/ci/container/internal/opensearch-dashboards-testing/vars.yml
+++ b/ci/container/internal/opensearch-dashboards-testing/vars.yml
@@ -4,3 +4,4 @@ src-repo: cloud-gov/opensearch-dashboards-cf-auth-proxy
 src-repo-uri: git@github.com:cloud-gov/opensearch-dashboards-cf-auth-proxy.git
 src-target-branch: main
 src-trigger: true
+enable-concourse-validation: "false"

--- a/ci/container/internal/opensearch-testing/vars.yml
+++ b/ci/container/internal/opensearch-testing/vars.yml
@@ -4,3 +4,4 @@ src-repo: cloud-gov/opensearch-dashboards-cf-auth-proxy
 src-repo-uri: git@github.com:cloud-gov/opensearch-dashboards-cf-auth-proxy.git
 src-target-branch: main
 src-trigger: true
+enable-concourse-validation: "false"

--- a/ci/container/internal/zap-runner/vars.yml
+++ b/ci/container/internal/zap-runner/vars.yml
@@ -2,3 +2,4 @@ image-repository: zap-runner
 src-repo: cloud-gov/zap-runner
 src-repo-uri: https://github.com/cloud-gov/zap-runner
 src-branch: 2026-03-18_update
+enable-concourse-validation: "false"


### PR DESCRIPTION
## Changes proposed in this pull request:

- This disables the concourse integration tests for certain images where the tests were failing.
- These tests are failing because they need their configuration set up slightly different, not because of any issue with the image

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Removing failing tests until they can be fixed, but they currently have no security implications
