### PR TITLE
updates the openssl version for openresty

### DIFF
--- a/container/dockerfiles/openresty/Dockerfile
+++ b/container/dockerfiles/openresty/Dockerfile
@@ -10,7 +10,7 @@ ARG RESTY_VERSION="1.31.1.1"
 ARG RESTY_LUAROCKS_VERSION="3.13.0"
 
 # https://github.com/openresty/openresty-packaging/blob/master/deb/openresty-openssl3/debian/rules
-ARG RESTY_OPENSSL_VERSION="3.5.6"
+ARG RESTY_OPENSSL_VERSION="3.5.7"
 ARG RESTY_OPENSSL_PATCH_VERSION="3.5.5"
 ARG RESTY_OPENSSL_URL_BASE="https://github.com/openssl/openssl/releases/download/openssl-${RESTY_OPENSSL_VERSION}"
 # LEGACY:  "https://www.openssl.org/source/old/1.1.1"


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updates the openssl version in the openresty image

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Updating the openssl version should resolve CVEs
