### PR TITLE
Fix Concourse resource protocol tests: exit-code gating and git promp…

### DIFF
--- a/container/concourse-tests/README.md
+++ b/container/concourse-tests/README.md
@@ -77,8 +77,12 @@ set -e
 ct_bootstrap <image-repository> <resource|service|runtime>
 ```
 
-Bespoke scripts that don't use a helper library (e.g. `general-task`,
-`s3-resource`) source `common.sh` directly and call `setup_workspace`.
+Bespoke scripts that don't use a helper library (e.g. `general-task`) source
+`common.sh` directly and call `setup_workspace`. All `*-resource` scripts —
+including `s3-resource`, `github-release-resource`, and
+`slack-notification-resource` — use `ct_bootstrap ... resource` and the shared
+`check_protocol`/`in_protocol`/`out_protocol` helpers so protocol validation is
+identical across every resource image.
 
 ## Image Inventory
 
@@ -209,7 +213,7 @@ cat src/file.txt > output/result.txt
 ## Examples by Image Type
 
 See existing scripts for reference:
-- **Resources:** `s3-resource.sh`, `github-pr-resource.sh` (or the shared `lib/resource-helpers.sh` consumers like `git-resource.sh`, `time-resource.sh`)
+- **Resources:** `s3-resource.sh`, `git-resource.sh`, `time-resource.sh` (all consume the shared `lib/resource-helpers.sh`)
 - **Task images:** `general-task.sh`
 - **Runtime images:** `pages-node-v22.sh`, `pages-python-v3.11.sh`, `pages-nginx-v1.sh` (delegate to `lib/runtime-helpers.sh`)
 - **Service images (offline smoke):** `openresty.sh`, `pages-postgres-v15.sh`, `pages-redis-v7.2.sh`, `cloud-service-broker.sh`

--- a/container/concourse-tests/concourse-rwlock-resource.sh
+++ b/container/concourse-tests/concourse-rwlock-resource.sh
@@ -6,6 +6,9 @@ set -e
 
 ct_bootstrap concourse-rwlock-resource resource
 
+# rwlock resource is git-backed; ensure git never blocks on a credential prompt.
+git_noninteractive
+
 # rwlock resource manages read/write locks in a git repo. Without a reachable
 # repo the scripts fail; we validate protocol compliance and git availability.
 check_protocol '{"source":{"uri":"https://github.com/cloud-gov/example.git","branch":"main"},"version":null}'

--- a/container/concourse-tests/git-resource.sh
+++ b/container/concourse-tests/git-resource.sh
@@ -6,6 +6,9 @@ set -e
 
 ct_bootstrap git-resource resource
 
+# git-resource is git-backed; ensure git never blocks on a credential prompt.
+git_noninteractive
+
 # git-resource clones/checks git repositories. Without network access the
 # scripts fail; we validate protocol compliance and git availability.
 check_protocol '{"source":{"uri":"https://github.com/cloud-gov/example.git","branch":"main"},"version":null}'

--- a/container/concourse-tests/github-pr-resource.sh
+++ b/container/concourse-tests/github-pr-resource.sh
@@ -4,77 +4,17 @@ set -e
 # shellcheck source=lib/common.sh
 . "$(cd "$(dirname "$0")/lib" && pwd)/common.sh"
 
-echo "  → Testing github-pr-resource in Concourse context"
-setup_workspace
+ct_bootstrap github-pr-resource resource
 
-# Test 1: Check script protocol
-echo "  → Testing /opt/resource/check protocol"
-cat > check-input.json <<EOF
-{
-  "source": {
-    "repository": "cloud-gov/example",
-    "access_token": "fake-token-for-testing"
-  },
-  "version": null
-}
-EOF
+# github-pr-resource lists/fetches/updates GitHub pull requests. Without a valid
+# token/network the scripts fail; the shared helpers validate protocol
+# compliance and tolerate the expected non-zero exit (see
+# lib/resource-helpers.sh).
+check_protocol '{"source":{"repository":"cloud-gov/example","access_token":"fake-token-for-testing"},"version":null}'
+in_protocol    '{"source":{"repository":"cloud-gov/example","access_token":"fake-token"},"version":{"pr":"1","commit":"abc123"}}'
+out_protocol   '{"source":{"repository":"cloud-gov/example","access_token":"fake-token"},"params":{"path":"src","status":"success"}}'
 
-/opt/resource/check < check-input.json > check-output.json || {
-  echo "  ℹ check script exited with error (expected without valid token)"
-}
-
-if [ -f check-output.json ] && [ -s check-output.json ]; then
-  jq -e 'type == "array" or (type == "object" and has("error"))' check-output.json >/dev/null 2>&1 && \
-    echo "  ✓ check returns valid JSON"
-fi
-
-# Test 2: In script protocol
-echo "  → Testing /opt/resource/in protocol"
-cat > in-input.json <<EOF
-{
-  "source": {
-    "repository": "cloud-gov/example",
-    "access_token": "fake-token"
-  },
-  "version": {"pr": "1", "commit": "abc123"}
-}
-EOF
-
-mkdir -p src
-/opt/resource/in src < in-input.json > in-output.json || {
-  echo "  ℹ in script exited with error (expected without valid token)"
-}
-
-if [ -f in-output.json ] && [ -s in-output.json ]; then
-  jq -e 'type == "object"' in-output.json >/dev/null 2>&1 && \
-    echo "  ✓ in returns JSON object"
-fi
-
-# Test 3: Out script protocol (PR comments)
-echo "  → Testing /opt/resource/out protocol"
-cat > out-input.json <<EOF
-{
-  "source": {
-    "repository": "cloud-gov/example",
-    "access_token": "fake-token"
-  },
-  "params": {
-    "path": "src",
-    "status": "success"
-  }
-}
-EOF
-
-/opt/resource/out src < out-input.json > out-output.json || {
-  echo "  ℹ out script exited with error (expected without valid token)"
-}
-
-if [ -f out-output.json ] && [ -s out-output.json ]; then
-  jq -e 'type == "object"' out-output.json >/dev/null 2>&1 && \
-    echo "  ✓ out returns JSON object"
-fi
-
-# Test 4: Git available (PR resource requires it)
+# Test: git available (PR resource requires it)
 echo "  → Testing git availability"
 git --version >/dev/null 2>&1 && echo "  ✓ git available"
 

--- a/container/concourse-tests/github-release-resource.sh
+++ b/container/concourse-tests/github-release-resource.sh
@@ -4,80 +4,17 @@ set -e
 # shellcheck source=lib/common.sh
 . "$(cd "$(dirname "$0")/lib" && pwd)/common.sh"
 
-echo "  → Testing github-release-resource in Concourse context"
-setup_workspace
+ct_bootstrap github-release-resource resource
 
-# Test 1: Check script protocol
-echo "  → Testing /opt/resource/check protocol"
-cat > check-input.json <<EOF
-{
-  "source": {
-    "owner": "cloud-gov",
-    "repository": "example",
-    "access_token": "fake-token"
-  },
-  "version": null
-}
-EOF
+# github-release-resource lists/downloads/publishes GitHub releases. Without a
+# valid token/network the scripts fail; the shared helpers validate protocol
+# compliance and tolerate the expected non-zero exit (see
+# lib/resource-helpers.sh).
+check_protocol '{"source":{"owner":"cloud-gov","repository":"example","access_token":"fake-token"},"version":null}'
+in_protocol    '{"source":{"owner":"cloud-gov","repository":"example","access_token":"fake-token"},"version":{"tag":"v1.0.0"}}'
+out_protocol   '{"source":{"owner":"cloud-gov","repository":"example","access_token":"fake-token"},"params":{"name":"v1.0.0","tag":"v1.0.0"}}'
 
-/opt/resource/check < check-input.json > check-output.json || {
-  echo "  ℹ check script exited with error (expected without valid token)"
-}
-
-if [ -f check-output.json ] && [ -s check-output.json ]; then
-  jq -e 'type == "array" or (type == "object" and has("error"))' check-output.json >/dev/null 2>&1 && \
-    echo "  ✓ check returns valid JSON"
-fi
-
-# Test 2: In script protocol
-echo "  → Testing /opt/resource/in protocol"
-cat > in-input.json <<EOF
-{
-  "source": {
-    "owner": "cloud-gov",
-    "repository": "example",
-    "access_token": "fake-token"
-  },
-  "version": {"tag": "v1.0.0"}
-}
-EOF
-
-mkdir -p src
-/opt/resource/in src < in-input.json > in-output.json || {
-  echo "  ℹ in script exited with error (expected without valid token)"
-}
-
-if [ -f in-output.json ] && [ -s in-output.json ]; then
-  jq -e 'type == "object"' in-output.json >/dev/null 2>&1 && \
-    echo "  ✓ in returns JSON object"
-fi
-
-# Test 3: Out script protocol
-echo "  → Testing /opt/resource/out protocol"
-cat > out-input.json <<EOF
-{
-  "source": {
-    "owner": "cloud-gov",
-    "repository": "example",
-    "access_token": "fake-token"
-  },
-  "params": {
-    "name": "v1.0.0",
-    "tag": "v1.0.0"
-  }
-}
-EOF
-
-/opt/resource/out src < out-input.json > out-output.json || {
-  echo "  ℹ out script exited with error (expected without valid token)"
-}
-
-if [ -f out-output.json ] && [ -s out-output.json ]; then
-  jq -e 'type == "object"' out-output.json >/dev/null 2>&1 && \
-    echo "  ✓ out returns JSON object"
-fi
-
-# Test 4: Git available (release resource may need it)
+# Test: git available (release resource may need it)
 echo "  → Testing git availability"
 git --version >/dev/null 2>&1 && echo "  ✓ git available"
 

--- a/container/concourse-tests/lib/resource-helpers.sh
+++ b/container/concourse-tests/lib/resource-helpers.sh
@@ -21,6 +21,29 @@
 # Backwards-compatible alias: older scripts call resource_setup_workspace.
 resource_setup_workspace() { setup_workspace; }
 
+# Force git into non-interactive, fail-fast mode for git-backed resource tests.
+#
+# Without valid credentials/network, git's credential subsystem falls back to an
+# interactive "Username for 'https://...':" prompt. In a Concourse task a
+# terminal is attached, so git blocks on that prompt forever and the test never
+# completes. These exported settings make git fail fast instead of prompting:
+#   GIT_TERMINAL_PROMPT=0  disables the username/password terminal prompt
+#   GIT_ASKPASS=true       makes any askpass invocation return empty immediately
+#   GCM_INTERACTIVE=never  disables the Git Credential Manager prompt (if present)
+#   credential.helper=""   clears any inherited helper that might prompt
+# Exported so they are inherited by git invoked inside /opt/resource/{check,in,out}.
+# Call this near the top of any git-backed resource test (git, pool, rwlock,
+# semver with driver=git, etc.).
+git_noninteractive() {
+  export GIT_TERMINAL_PROMPT=0
+  export GIT_ASKPASS=true
+  export GCM_INTERACTIVE=never
+  export GIT_CONFIG_COUNT=1
+  export GIT_CONFIG_KEY_0=credential.helper
+  export GIT_CONFIG_VALUE_0=
+  echo "  ℹ git configured for non-interactive mode (no credential prompts)"
+}
+
 # Assert an /opt/resource/<name> script exists and is executable.
 # Usage: assert_resource_script check
 assert_resource_script() {
@@ -34,69 +57,105 @@ assert_resource_script() {
   return 1
 }
 
-# Run /opt/resource/check with the given JSON payload and validate that any
-# output is a JSON array (success) or a JSON object (error report). A non-zero
-# exit without credentials is tolerated.
+# Run /opt/resource/check with the given JSON payload and validate protocol
+# compliance. Per the Concourse resource contract, check writes a JSON array to
+# stdout ONLY on success; failure is signaled by a non-zero exit code with
+# diagnostics on stderr (stdout is not required to be JSON in that case).
+#
+# We therefore gate stdout validation on the exit code:
+#   - exit 0  -> stdout MUST be a JSON array (or a JSON error object, which some
+#                resources emit); anything else is a protocol violation.
+#   - exit !0 -> expected here (no credentials/network). Any stdout is advisory
+#                only: we report whether it happens to be protocol-shaped, but a
+#                non-JSON diagnostic on stdout is NOT a failure.
 # Usage: check_protocol <payload-json>
 check_protocol() {
   local payload="$1"
   assert_resource_script check || return 1
   printf '%s' "$payload" > check-input.json
-  /opt/resource/check < check-input.json > check-output.json 2>/dev/null || \
-    echo "  ℹ check exited non-zero (expected without credentials/network)"
-  if [ -s check-output.json ]; then
-    if jq -e 'type == "array" or (type == "object" and has("error"))' \
+  local rc=0
+  /opt/resource/check < check-input.json > check-output.json 2>/dev/null || rc=$?
+
+  if [ "$rc" -eq 0 ]; then
+    # Success: stdout must be protocol-compliant JSON.
+    if [ -s check-output.json ] && jq -e \
+        'type == "array" or (type == "object" and has("error"))' \
         check-output.json >/dev/null 2>&1; then
       echo "  ✓ check emits protocol-compliant JSON"
     else
-      echo "  ✗ check output is not a JSON array/error object"
+      echo "  ✗ check exited 0 but stdout is not a JSON array/error object"
       return 1
     fi
   else
-    echo "  ℹ check produced no output (acceptable on credential failure)"
+    # Non-zero exit is expected without credentials/network. stdout is advisory.
+    echo "  ℹ check exited non-zero (expected without credentials/network)"
+    if [ -s check-output.json ]; then
+      if jq -e 'type == "array" or (type == "object" and has("error"))' \
+          check-output.json >/dev/null 2>&1; then
+        echo "  ✓ check still emitted protocol-compliant JSON on failure"
+      else
+        echo "  ℹ check wrote non-JSON diagnostics to stdout on failure (tolerated)"
+      fi
+    else
+      echo "  ℹ check produced no stdout (diagnostics go to stderr; acceptable)"
+    fi
   fi
 }
 
-# Run /opt/resource/in <dest> with the given JSON payload and validate that any
-# output is a JSON object.
+# Run /opt/resource/in <dest> with the given JSON payload and validate protocol
+# compliance. On success (exit 0) stdout MUST be a JSON object; on the expected
+# non-zero exit (no credentials/network) stdout is advisory only.
 # Usage: in_protocol <payload-json>
 in_protocol() {
   local payload="$1"
   assert_resource_script in || return 1
   mkdir -p dest
   printf '%s' "$payload" > in-input.json
-  /opt/resource/in dest < in-input.json > in-output.json 2>/dev/null || \
-    echo "  ℹ in exited non-zero (expected without credentials/network)"
-  if [ -s in-output.json ]; then
-    if jq -e 'type == "object"' in-output.json >/dev/null 2>&1; then
+  local rc=0
+  /opt/resource/in dest < in-input.json > in-output.json 2>/dev/null || rc=$?
+
+  if [ "$rc" -eq 0 ]; then
+    if [ -s in-output.json ] && jq -e 'type == "object"' in-output.json >/dev/null 2>&1; then
       echo "  ✓ in emits a JSON object"
     else
-      echo "  ✗ in output is not a JSON object"
+      echo "  ✗ in exited 0 but stdout is not a JSON object"
       return 1
     fi
   else
-    echo "  ℹ in produced no output (acceptable on credential failure)"
+    echo "  ℹ in exited non-zero (expected without credentials/network)"
+    if [ -s in-output.json ] && jq -e 'type == "object"' in-output.json >/dev/null 2>&1; then
+      echo "  ✓ in still emitted a JSON object on failure"
+    else
+      echo "  ℹ in produced no protocol JSON on stdout (diagnostics go to stderr; acceptable)"
+    fi
   fi
 }
 
-# Run /opt/resource/out <src> with the given JSON payload and validate that any
-# output is a JSON object.
+# Run /opt/resource/out <src> with the given JSON payload and validate protocol
+# compliance. On success (exit 0) stdout MUST be a JSON object; on the expected
+# non-zero exit (no credentials/network) stdout is advisory only.
 # Usage: out_protocol <payload-json>
 out_protocol() {
   local payload="$1"
   assert_resource_script out || return 1
   mkdir -p src
   printf '%s' "$payload" > out-input.json
-  /opt/resource/out src < out-input.json > out-output.json 2>/dev/null || \
-    echo "  ℹ out exited non-zero (expected without credentials/network)"
-  if [ -s out-output.json ]; then
-    if jq -e 'type == "object"' out-output.json >/dev/null 2>&1; then
+  local rc=0
+  /opt/resource/out src < out-input.json > out-output.json 2>/dev/null || rc=$?
+
+  if [ "$rc" -eq 0 ]; then
+    if [ -s out-output.json ] && jq -e 'type == "object"' out-output.json >/dev/null 2>&1; then
       echo "  ✓ out emits a JSON object"
     else
-      echo "  ✗ out output is not a JSON object"
+      echo "  ✗ out exited 0 but stdout is not a JSON object"
       return 1
     fi
   else
-    echo "  ℹ out produced no output (acceptable on credential failure)"
+    echo "  ℹ out exited non-zero (expected without credentials/network)"
+    if [ -s out-output.json ] && jq -e 'type == "object"' out-output.json >/dev/null 2>&1; then
+      echo "  ✓ out still emitted a JSON object on failure"
+    else
+      echo "  ℹ out produced no protocol JSON on stdout (diagnostics go to stderr; acceptable)"
+    fi
   fi
 }

--- a/container/concourse-tests/pool-resource.sh
+++ b/container/concourse-tests/pool-resource.sh
@@ -6,6 +6,9 @@ set -e
 
 ct_bootstrap pool-resource resource
 
+# pool-resource is git-backed; ensure git never blocks on a credential prompt.
+git_noninteractive
+
 # pool-resource manages a pool of locks stored in a git repo. Without a
 # reachable repo the scripts fail; we validate protocol compliance and git
 # availability.

--- a/container/concourse-tests/s3-resource.sh
+++ b/container/concourse-tests/s3-resource.sh
@@ -4,90 +4,22 @@ set -e
 # shellcheck source=lib/common.sh
 . "$(cd "$(dirname "$0")/lib" && pwd)/common.sh"
 
-echo "  → Testing s3-resource in Concourse context"
-setup_workspace
+ct_bootstrap s3-resource resource
 
-# Test 1: Check script protocol
-echo "  → Testing /opt/resource/check protocol"
-cat > check-input.json <<EOF
-{
-  "source": {
-    "bucket": "test-bucket",
-    "region_name": "us-gov-west-1"
-  },
-  "version": null
-}
-EOF
+# s3-resource pulls/pushes objects from an S3 bucket. Without credentials/network
+# the scripts fail; the shared helpers validate protocol compliance and tolerate
+# the expected non-zero exit (see lib/resource-helpers.sh).
+check_protocol '{"source":{"bucket":"test-bucket","region_name":"us-gov-west-1"},"version":null}'
+in_protocol    '{"source":{"bucket":"test-bucket","region_name":"us-gov-west-1"},"version":{"path":"test.txt"},"params":{}}'
+out_protocol   '{"source":{"bucket":"test-bucket","region_name":"us-gov-west-1"},"params":{"file":"src/test.txt"}}'
 
-/opt/resource/check < check-input.json > check-output.json || {
-  echo "  ℹ check script exited with error (expected without credentials)"
-}
-
-# Verify output structure even on error
-if [ -f check-output.json ] && [ -s check-output.json ]; then
-  if jq -e 'type == "array"' check-output.json >/dev/null 2>&1; then
-    echo "  ✓ check returns JSON array"
-  elif jq -e 'type == "object" and has("error")' check-output.json >/dev/null 2>&1; then
-    echo "  ✓ check returns error object (JSON format correct)"
-  fi
-fi
-
-# Test 2: In script protocol
-echo "  → Testing /opt/resource/in protocol"
-cat > in-input.json <<EOF
-{
-  "source": {
-    "bucket": "test-bucket",
-    "region_name": "us-gov-west-1"
-  },
-  "version": {"path": "test.txt"},
-  "params": {}
-}
-EOF
-
-mkdir -p src
-/opt/resource/in src < in-input.json > in-output.json || {
-  echo "  ℹ in script exited with error (expected without credentials)"
-}
-
-if [ -f in-output.json ] && [ -s in-output.json ]; then
-  if jq -e 'type == "object"' in-output.json >/dev/null 2>&1; then
-    echo "  ✓ in returns JSON object"
-  fi
-fi
-
-# Test 3: Out script protocol
-echo "  → Testing /opt/resource/out protocol"
-cat > out-input.json <<EOF
-{
-  "source": {
-    "bucket": "test-bucket",
-    "region_name": "us-gov-west-1"
-  },
-  "params": {
-    "file": "src/test.txt"
-  }
-}
-EOF
-
-echo "test content" > src/test.txt
-/opt/resource/out src < out-input.json > out-output.json || {
-  echo "  ℹ out script exited with error (expected without credentials)"
-}
-
-if [ -f out-output.json ] && [ -s out-output.json ]; then
-  if jq -e 'type == "object"' out-output.json >/dev/null 2>&1; then
-    echo "  ✓ out returns JSON object"
-  fi
-fi
-
-# Test 4: AWS CLI available (s3-resource requires it)
+# Test: AWS CLI available (s3-resource requires it)
 echo "  → Testing AWS CLI"
 aws --version >/dev/null 2>&1 && echo "  ✓ AWS CLI available"
 
-# Test 5: Required environment handling
+# Test: FIPS endpoint support
 echo "  → Testing FIPS endpoint support"
-if [ "$AWS_USE_FIPS_ENDPOINT" = "true" ]; then
+if [ "${AWS_USE_FIPS_ENDPOINT:-}" = "true" ]; then
   echo "  ✓ FIPS endpoint configuration present"
 else
   echo "  ⚠ AWS_USE_FIPS_ENDPOINT not set (should be 'true')"

--- a/container/concourse-tests/semver-resource.sh
+++ b/container/concourse-tests/semver-resource.sh
@@ -6,6 +6,10 @@ set -e
 
 ct_bootstrap semver-resource resource
 
+# semver-resource here uses the git driver; ensure git never blocks on a
+# credential prompt.
+git_noninteractive
+
 # semver-resource manages a semantic version stored in a backing driver
 # (git/s3/etc). Without a reachable backend the scripts fail; we validate
 # protocol compliance.

--- a/container/concourse-tests/slack-notification-resource.sh
+++ b/container/concourse-tests/slack-notification-resource.sh
@@ -4,82 +4,31 @@ set -e
 # shellcheck source=lib/common.sh
 . "$(cd "$(dirname "$0")/lib" && pwd)/common.sh"
 
-echo "  → Testing slack-notification-resource in Concourse context"
-setup_workspace
+ct_bootstrap slack-notification-resource resource
 
-# Test 1: Check script protocol (Slack notification doesn't implement check)
-echo "  → Testing /opt/resource/check protocol"
-if [ -f /opt/resource/check ]; then
-  cat > check-input.json <<EOF
-{
-  "source": {
-    "url": "https://hooks.slack.com/services/fake/webhook"
-  },
-  "version": null
-}
-EOF
+# slack-notification-resource is an out-only notification resource: check/in are
+# frequently not implemented, so we guard those and only require the out
+# protocol. The shared helpers validate protocol compliance and tolerate the
+# expected non-zero exit without a real webhook (see lib/resource-helpers.sh).
 
-  /opt/resource/check < check-input.json > check-output.json || {
-    echo "  ℹ check script exited with error (expected for notification resource)"
-  }
-
-  if [ -f check-output.json ] && [ -s check-output.json ]; then
-    jq -e 'type == "array"' check-output.json >/dev/null 2>&1 && \
-      echo "  ✓ check returns JSON array"
-  fi
+# check is optional for this resource.
+if [ -x /opt/resource/check ]; then
+  check_protocol '{"source":{"url":"https://hooks.slack.com/services/fake/webhook"},"version":null}'
 else
   echo "  ℹ check not implemented (expected for notification resource)"
 fi
 
-# Test 2: In script protocol (usually just returns empty)
-echo "  → Testing /opt/resource/in protocol"
-if [ -f /opt/resource/in ]; then
-  cat > in-input.json <<EOF
-{
-  "source": {
-    "url": "https://hooks.slack.com/services/fake/webhook"
-  },
-  "version": null
-}
-EOF
-
-  mkdir -p src
-  /opt/resource/in src < in-input.json > in-output.json || {
-    echo "  ℹ in script exited with error (expected for notification resource)"
-  }
-
-  if [ -f in-output.json ] && [ -s in-output.json ]; then
-    jq -e 'type == "object"' in-output.json >/dev/null 2>&1 && \
-      echo "  ✓ in returns JSON object"
-  fi
+# in is optional for this resource.
+if [ -x /opt/resource/in ]; then
+  in_protocol '{"source":{"url":"https://hooks.slack.com/services/fake/webhook"},"version":null}'
 else
-  echo "  ℹ in not fully implemented (may be acceptable)"
+  echo "  ℹ in not implemented (may be acceptable for notification resource)"
 fi
 
-# Test 3: Out script protocol (main functionality)
-echo "  → Testing /opt/resource/out protocol"
-cat > out-input.json <<EOF
-{
-  "source": {
-    "url": "https://hooks.slack.com/services/fake/webhook"
-  },
-  "params": {
-    "text": "Test notification"
-  }
-}
-EOF
+# out is the main functionality and must be present.
+out_protocol '{"source":{"url":"https://hooks.slack.com/services/fake/webhook"},"params":{"text":"Test notification"}}'
 
-mkdir -p src
-/opt/resource/out src < out-input.json > out-output.json || {
-  echo "  ℹ out script exited with error (expected without valid webhook)"
-}
-
-if [ -f out-output.json ] && [ -s out-output.json ]; then
-  jq -e 'type == "object"' out-output.json >/dev/null 2>&1 && \
-    echo "  ✓ out returns JSON object"
-fi
-
-# Test 4: curl available (needed for webhook calls)
+# Test: curl available (needed for webhook calls)
 echo "  → Testing curl availability"
 curl --version >/dev/null 2>&1 && echo "  ✓ curl available"
 


### PR DESCRIPTION
…t hangs

Two classes of failures in the concourse-tests resource protocol validation:

1. check/in/out validation ignored the resource exit code. Resources that follow the Concourse contract (e.g. registry-image-resource) write diagnostics to stderr and leave stdout empty on failure, which the old helper flagged as "not a JSON array/error object". Rework check_protocol, in_protocol, and out_protocol to gate on exit code: require valid JSON only on exit 0; tolerate non-JSON/empty stdout on the expected no-credential failure.

2. git-backed resources (git, pool, rwlock, semver with driver=git) hung forever on an interactive "Username for 'https://...':" prompt when run without credentials. Add a shared git_noninteractive helper that exports GIT_TERMINAL_PROMPT=0, GIT_ASKPASS=true, GCM_INTERACTIVE=never, and clears credential.helper so git fails fast instead of prompting.

Also migrate s3-resource, github-release-resource, github-pr-resource, and slack-notification-resource off their bespoke inline protocol logic onto the shared helpers so all resource images validate identically, and update the concourse-tests README accordingly.

Verified with bash -n on all touched scripts and by reproducing both the exit-code branches and the git credential-prompt behavior.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing failing concourse integration tests
